### PR TITLE
Specify AssertJ version

### DIFF
--- a/event-statistics/pom.xml
+++ b/event-statistics/pom.xml
@@ -18,6 +18,7 @@
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>2.6.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <assertj.version>3.22.0</assertj.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -95,6 +96,7 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
+      <version>${assertj.version}</version>
     </dependency>
     <dependency>
       <groupId>org.awaitility</groupId>

--- a/rest-fights/pom.xml
+++ b/rest-fights/pom.xml
@@ -17,6 +17,7 @@
     <quarkus.platform.version>2.6.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <wiremock.version>2.32.0</wiremock.version>
+    <assertj.version>3.22.0</assertj.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -126,6 +127,7 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
+      <version>${assertj.version}</version>
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>

--- a/rest-heroes/pom.xml
+++ b/rest-heroes/pom.xml
@@ -17,6 +17,7 @@
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>2.6.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <assertj.version>3.22.0</assertj.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -119,6 +120,7 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
+      <version>${assertj.version}</version>
     </dependency>
   </dependencies>
   <build>

--- a/rest-villains/pom.xml
+++ b/rest-villains/pom.xml
@@ -17,6 +17,7 @@
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>2.6.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <assertj.version>3.22.0</assertj.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -115,6 +116,7 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
+      <version>${assertj.version}</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
This is needed to make the repository work with
Quarkus built from `main` because AssertJ was removed
from the BOM (see https://github.com/quarkusio/quarkus/pull/18006)