### PR TITLE
Update prometheus

### DIFF
--- a/event-statistics/src/main/kubernetes/knative.yml
+++ b/event-statistics/src/main/kubernetes/knative.yml
@@ -94,6 +94,11 @@ spec:
       name: apicurio
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scheme: http
       labels:
         application: fights-service
         name: apicurio
@@ -138,6 +143,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
   labels:
     name: apicurio
     application: fights-service

--- a/event-statistics/src/main/kubernetes/kubernetes.yml
+++ b/event-statistics/src/main/kubernetes/kubernetes.yml
@@ -94,6 +94,11 @@ spec:
       name: apicurio
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scheme: http
       labels:
         application: fights-service
         name: apicurio
@@ -138,6 +143,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
   labels:
     name: apicurio
     application: fights-service

--- a/event-statistics/src/main/kubernetes/minikube.yml
+++ b/event-statistics/src/main/kubernetes/minikube.yml
@@ -94,6 +94,11 @@ spec:
       name: apicurio
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scheme: http
       labels:
         application: fights-service
         name: apicurio
@@ -138,6 +143,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
   labels:
     name: apicurio
     application: fights-service

--- a/event-statistics/src/main/kubernetes/openshift.yml
+++ b/event-statistics/src/main/kubernetes/openshift.yml
@@ -94,6 +94,11 @@ spec:
       name: apicurio
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scheme: http
       labels:
         application: fights-service
         name: apicurio
@@ -138,6 +143,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
   labels:
     name: apicurio
     application: fights-service
@@ -155,6 +165,11 @@ spec:
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
   labels:
     app: apicurio
     application: fights-service

--- a/monitoring/config/prometheus_scrape_configs_k8s.yml
+++ b/monitoring/config/prometheus_scrape_configs_k8s.yml
@@ -18,8 +18,7 @@ scrape_configs:
     kubernetes_sd_configs:
       - role: pod
         namespaces:
-          names:
-            - <<NAME_OF_K8S_NAMESPACE>>
+          own_namespace: true
     relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep

--- a/monitoring/docker-compose/prometheus.yml
+++ b/monitoring/docker-compose/prometheus.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
 
   prometheus:
-    image: quay.io/prometheus/prometheus:v2.32.1
+    image: quay.io/prometheus/prometheus:v2.33.1
     container_name: prometheus
     ports:
       - "9090:9090"

--- a/monitoring/k8s/base.yml
+++ b/monitoring/k8s/base.yml
@@ -1,4 +1,16 @@
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: default_view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: default
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,69 +23,43 @@ data:
       scrape_interval: 10s
       external_labels:
         system: quarkus-super-heroes
-      
+    
     scrape_configs:
       - job_name: prometheus
         static_configs:
           - targets: ['localhost:9090']
 
-      - job_name: apicurio
-        honor_labels: true
-        static_configs:
-          - targets: ['apicurio:8080']
-            labels:
-              app: apicurio
-              application: fights-service
-              system: quarkus-super-heroes
-      
-      - job_name: heroes
-        metrics_path: /q/metrics
-        honor_labels: true
-        static_configs:
-          - targets: ['rest-heroes']
-            labels:
-              app: rest-heroes
-              application: heroes-service
-              system: quarkus-super-heroes
-      
-      - job_name: villains
-        metrics_path: /q/metrics
-        honor_labels: true
-        static_configs:
-          - targets: ['rest-villains']
-            labels:
-              app: rest-villains
-              application: villains-service
-              system: quarkus-super-heroes
-      
-      - job_name: fights
-        metrics_path: /q/metrics
-        honor_labels: true
-        static_configs:
-          - targets: ['rest-fights']
-            labels:
-              app: rest-fights
-              application: fights-service
-              system: quarkus-super-heroes
-      
-      - job_name: event-stats
-        metrics_path: /q/metrics
-        honor_labels: true
-        static_configs:
-          - targets: ['event-statistics']
-            labels:
-              app: event-statistics
-              application: event-stats
-              system: quarkus-super-heroes
-      
-      - job_name: ui-super-heroes
-        honor_labels: true
-        static_configs:
-          - targets: ['ui-super-heroes']
-            labels:
-              app: ui-super-heroes
-              application: super-heroes
-              system: quarkus-super-heroes
+      - job_name: k8s-discovery
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              own_namespace: true
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+            action: keep
+            regex: true
+          
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          
+          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+            action: replace
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+            target_label: __address__
+          
+          - action: labelmap
+            regex: __meta_kubernetes_pod_label_(.+)
+          
+          - source_labels: [__meta_kubernetes_namespace]
+            action: replace
+            target_label: kubernetes_namespace
+          
+          - source_labels: [__meta_kubernetes_pod_name]
+            action: replace
+            target_label: kubernetes_pod_name
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -85,7 +71,7 @@ metadata:
     app.kubernetes.io/part-of: super-heroes
     app.openshift.io/runtime: prometheus
   annotations:
-    app.openshift.io/connects-to: ui-super-heroes,rest-fights,rest-villains,rest-heroes,event-statistics
+    app.openshift.io/connects-to: ui-super-heroes,rest-fights,rest-villains,rest-heroes,event-statistics,apicurio
 spec:
   replicas: 1
   selector:
@@ -98,7 +84,7 @@ spec:
         name: prometheus
     spec:
       containers:
-        - image: quay.io/prometheus/prometheus:v2.32.1
+        - image: quay.io/prometheus/prometheus:v2.33.1
           name: prometheus
           ports:
             - containerPort: 9090

--- a/rest-fights/src/main/kubernetes/knative.yml
+++ b/rest-fights/src/main/kubernetes/knative.yml
@@ -191,6 +191,11 @@ spec:
       name: apicurio
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scheme: http
       labels:
         application: fights-service
         name: apicurio
@@ -235,6 +240,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
   labels:
     name: apicurio
     application: fights-service

--- a/rest-fights/src/main/kubernetes/kubernetes.yml
+++ b/rest-fights/src/main/kubernetes/kubernetes.yml
@@ -191,6 +191,11 @@ spec:
       name: apicurio
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scheme: http
       labels:
         application: fights-service
         name: apicurio
@@ -235,6 +240,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
   labels:
     name: apicurio
     application: fights-service

--- a/rest-fights/src/main/kubernetes/minikube.yml
+++ b/rest-fights/src/main/kubernetes/minikube.yml
@@ -191,6 +191,11 @@ spec:
       name: apicurio
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scheme: http
       labels:
         application: fights-service
         name: apicurio
@@ -235,6 +240,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
   labels:
     name: apicurio
     application: fights-service

--- a/rest-fights/src/main/kubernetes/openshift.yml
+++ b/rest-fights/src/main/kubernetes/openshift.yml
@@ -191,6 +191,11 @@ spec:
       name: apicurio
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scheme: http
       labels:
         application: fights-service
         name: apicurio
@@ -235,6 +240,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
   labels:
     name: apicurio
     application: fights-service
@@ -252,6 +262,11 @@ spec:
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
   labels:
     app: apicurio
     application: fights-service


### PR DESCRIPTION
Update prometheus to version `2.33`, which also allows for use of the [`kubernetes_sd_configs`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config) to scrape from just the same namespace in which its deployed.

The static configuration for the services aren't needed anymore in the k8s deployment (they are still needed for docker compose).

When committing #4 adding the prometheus annotations to the various apicurio resources was missed as well. This PR fixes that too.