### PR TITLE
Use the built-in compose of the docker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ Pick one of the 4 versions of the application from the table below and execute t
 
 | Description                  | Image Tag              | Docker Compose Run Command                                                      | Docker Compose Run Command with Prometheus Monitoring                                                                   |
 |------------------------------|------------------------|---------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
-| JVM Java 11                  | `java11-latest`        | `docker-compose -f deploy/docker-compose/java11.yml up --remove-orphans`        | `docker-compose -f deploy/docker-compose/java11.yml -f deploy/docker-compose/prometheus.yml up --remove-orphans`        |
-| JVM Java 17                  | `java17-latest`        | `docker-compose -f deploy/docker-compose/java17 up --remove-orphans`            | `docker-compose -f deploy/docker-compose/java17.yml -f deploy/docker-compose/prometheus.yml up --remove-orphans`        |
-| Native compiled with Java 11 | `native-java11-latest` | `docker-compose -f deploy/docker-compose/native-java11.yml up --remove-orphans` | `docker-compose -f deploy/docker-compose/native-java11.yml -f deploy/docker-compose/prometheus.yml up --remove-orphans` |
-| Native compiled with Java 17 | `native-java17-latest` | `docker-compose -f deploy/docker-compose/native-java17.yml up --remove-orphans` | `docker-compose -f deploy/docker-compose/native-java17.yml -f deploy/docker-compose/prometheus.yml up --remove-orphans` |
+| JVM Java 11                  | `java11-latest`        | `docker compose -f deploy/docker-compose/java11.yml up --remove-orphans`        | `docker compose -f deploy/docker-compose/java11.yml -f deploy/docker-compose/prometheus.yml up --remove-orphans`        |
+| JVM Java 17                  | `java17-latest`        | `docker compose -f deploy/docker-compose/java17 up --remove-orphans`            | `docker compose -f deploy/docker-compose/java17.yml -f deploy/docker-compose/prometheus.yml up --remove-orphans`        |
+| Native compiled with Java 11 | `native-java11-latest` | `docker compose -f deploy/docker-compose/native-java11.yml up --remove-orphans` | `docker compose -f deploy/docker-compose/native-java11.yml -f deploy/docker-compose/prometheus.yml up --remove-orphans` |
+| Native compiled with Java 17 | `native-java17-latest` | `docker compose -f deploy/docker-compose/native-java17.yml up --remove-orphans` | `docker compose -f deploy/docker-compose/native-java17.yml -f deploy/docker-compose/prometheus.yml up --remove-orphans` |
 
 Once started the main application will be exposed at `http://localhost:8080`. If you want to watch the [Event Statistics UI](event-statistics), that will be available at `http://localhost:8085`.
 

--- a/event-statistics/README.md
+++ b/event-statistics/README.md
@@ -90,10 +90,10 @@ Pick one of the 4 versions of the application from the table below and execute t
 
 | Description                  | Image Tag              | Docker Compose Run Command                                                      |
 |------------------------------|------------------------|---------------------------------------------------------------------------------|
-| JVM Java 11                  | `java11-latest`        | `docker-compose -f deploy/docker-compose/java11.yml up --remove-orphans`        |
-| JVM Java 17                  | `java17-latest`        | `docker-compose -f deploy/docker-compose/java17.yml up --remove-orphans`        |
-| Native compiled with Java 11 | `native-java11-latest` | `docker-compose -f deploy/docker-compose/native-java11.yml up --remove-orphans` |
-| Native compiled with Java 17 | `native-java17-latest` | `docker-compose -f deploy/docker-compose/native-java17.yml up --remove-orphans` |
+| JVM Java 11                  | `java11-latest`        | `docker compose -f deploy/docker-compose/java11.yml up --remove-orphans`        |
+| JVM Java 17                  | `java17-latest`        | `docker compose -f deploy/docker-compose/java17.yml up --remove-orphans`        |
+| Native compiled with Java 11 | `native-java11-latest` | `docker compose -f deploy/docker-compose/native-java11.yml up --remove-orphans` |
+| Native compiled with Java 17 | `native-java17-latest` | `docker compose -f deploy/docker-compose/native-java17.yml up --remove-orphans` |
 
 These Docker Compose files are meant for standing up this application and the required Kafka broker only. If you want to stand up the entire system, [follow these instructions](../README.md#running-locally-via-docker-compose).
 

--- a/rest-fights/README.md
+++ b/rest-fights/README.md
@@ -104,10 +104,10 @@ Pick one of the 4 versions of the application from the table below and execute t
 
 | Description                  | Image Tag              | Docker Compose Run Command                                                      |
 |------------------------------|------------------------|---------------------------------------------------------------------------------|
-| JVM Java 11                  | `java11-latest`        | `docker-compose -f deploy/docker-compose/java11.yml up --remove-orphans`        |
-| JVM Java 17                  | `java17-latest`        | `docker-compose -f deploy/docker-compose/java17.yml up --remove-orphans`        |
-| Native compiled with Java 11 | `native-java11-latest` | `docker-compose -f deploy/docker-compose/native-java11.yml up --remove-orphans` |
-| Native compiled with Java 17 | `native-java17-latest` | `docker-compose -f deploy/docker-compose/native-java17.yml up --remove-orphans` |
+| JVM Java 11                  | `java11-latest`        | `docker compose -f deploy/docker-compose/java11.yml up --remove-orphans`        |
+| JVM Java 17                  | `java17-latest`        | `docker compose -f deploy/docker-compose/java17.yml up --remove-orphans`        |
+| Native compiled with Java 11 | `native-java11-latest` | `docker compose -f deploy/docker-compose/native-java11.yml up --remove-orphans` |
+| Native compiled with Java 17 | `native-java17-latest` | `docker compose -f deploy/docker-compose/native-java17.yml up --remove-orphans` |
 
 ### Fights Service and all Downstream Dependencies
 The above Docker Compose files are meant for standing up this application and the required database, Kafka broker, and Apicurio Schema Registry only. If you want to stand up this application and its downstream services ([rest-villains](../rest-villains) and [rest-heroes](../rest-heroes)), pick one of the 4 versions from the table below and execute the appropriate docker compose command from the `quarkus-super-heroes/rest-fights` directory.
@@ -116,10 +116,10 @@ The above Docker Compose files are meant for standing up this application and th
 
 | Description                  | Image Tag              | Docker Compose Run Command                                                                     |
 |------------------------------|------------------------|------------------------------------------------------------------------------------------------|
-| JVM Java 11                  | `java11-latest`        | `docker-compose -f deploy/docker-compose/java11-all-downstream.yml up --remove-orphans`        |
-| JVM Java 17                  | `java17-latest`        | `docker-compose -f deploy/docker-compose/java17-all-downstream.yml up --remove-orphans`        |
-| Native compiled with Java 11 | `native-java11-latest` | `docker-compose -f deploy/docker-compose/native-java11-all-downstream.yml up --remove-orphans` |
-| Native compiled with Java 17 | `native-java17-latest` | `docker-compose -f deploy/docker-compose/native-java17-all-downstream.yml up --remove-orphans` |
+| JVM Java 11                  | `java11-latest`        | `docker compose -f deploy/docker-compose/java11-all-downstream.yml up --remove-orphans`        |
+| JVM Java 17                  | `java17-latest`        | `docker compose -f deploy/docker-compose/java17-all-downstream.yml up --remove-orphans`        |
+| Native compiled with Java 11 | `native-java11-latest` | `docker compose -f deploy/docker-compose/native-java11-all-downstream.yml up --remove-orphans` |
+| Native compiled with Java 17 | `native-java17-latest` | `docker compose -f deploy/docker-compose/native-java17-all-downstream.yml up --remove-orphans` |
 
 ### Only Downstream Dependencies
 If you want to develop the Fights service (i.e. via [Quarkus Dev Mode](https://quarkus.io/guides/maven-tooling#dev-mode)) but want to stand up just it's downstream services ([rest-villains](../rest-villains) and [rest-heroes](../rest-heroes)), pick one of the 4 versions from the table below and execute the appropriate docker compose command from the `quarkus-super-heroes` directory.
@@ -128,10 +128,10 @@ If you want to develop the Fights service (i.e. via [Quarkus Dev Mode](https://q
 
 | Description                  | Image Tag              | Docker Compose Run Command                                                                                                                           |
 |------------------------------|------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| JVM Java 11                  | `java11-latest`        | `docker-compose -f rest-heroes/deploy/docker-compose/java11.yml -f rest-villains/deploy/docker-compose/java11.yml up --remove-orphans`               |
-| JVM Java 17                  | `java17-latest`        | `docker-compose -f rest-heroes/deploy/docker-compose/java17.yml -f rest-villains/deploy/docker-compose/java17.yml up --remove-orphans`               |
-| Native compiled with Java 11 | `native-java11-latest` | `docker-compose -f rest-heroes/deploy/docker-compose/native-java11.yml -f rest-villains/deploy/docker-compose/native-java11.yml up --remove-orphans` |
-| Native compiled with Java 17 | `native-java17-latest` | `docker-compose -f rest-heroes/deploy/docker-compose/native-java17.yml -f rest-villains/deploy/docker-compose/native-java17.yml up --remove-orphans` |                                                 |
+| JVM Java 11                  | `java11-latest`        | `docker compose -f rest-heroes/deploy/docker-compose/java11.yml -f rest-villains/deploy/docker-compose/java11.yml up --remove-orphans`               |
+| JVM Java 17                  | `java17-latest`        | `docker compose -f rest-heroes/deploy/docker-compose/java17.yml -f rest-villains/deploy/docker-compose/java17.yml up --remove-orphans`               |
+| Native compiled with Java 11 | `native-java11-latest` | `docker compose -f rest-heroes/deploy/docker-compose/native-java11.yml -f rest-villains/deploy/docker-compose/native-java11.yml up --remove-orphans` |
+| Native compiled with Java 17 | `native-java17-latest` | `docker compose -f rest-heroes/deploy/docker-compose/native-java17.yml -f rest-villains/deploy/docker-compose/native-java17.yml up --remove-orphans` |                                                 |
 
 If you want to stand up the entire system, [follow these instructions](../README.md#running-locally-via-docker-compose).
 

--- a/rest-heroes/README.md
+++ b/rest-heroes/README.md
@@ -64,10 +64,10 @@ Pick one of the 4 versions of the application from the table below and execute t
 
 | Description                  | Image Tag              | Docker Compose Run Command                                                      |
 |------------------------------|------------------------|---------------------------------------------------------------------------------|
-| JVM Java 11                  | `java11-latest`        | `docker-compose -f deploy/docker-compose/java11.yml up --remove-orphans`        |
-| JVM Java 17                  | `java17-latest`        | `docker-compose -f deploy/docker-compose/java17.yml up --remove-orphans`        |
-| Native compiled with Java 11 | `native-java11-latest` | `docker-compose -f deploy/docker-compose/native-java11.yml up --remove-orphans` |
-| Native compiled with Java 17 | `native-java17-latest` | `docker-compose -f deploy/docker-compose/native-java17.yml up --remove-orphans` |
+| JVM Java 11                  | `java11-latest`        | `docker compose -f deploy/docker-compose/java11.yml up --remove-orphans`        |
+| JVM Java 17                  | `java17-latest`        | `docker compose -f deploy/docker-compose/java17.yml up --remove-orphans`        |
+| Native compiled with Java 11 | `native-java11-latest` | `docker compose -f deploy/docker-compose/native-java11.yml up --remove-orphans` |
+| Native compiled with Java 17 | `native-java17-latest` | `docker compose -f deploy/docker-compose/native-java17.yml up --remove-orphans` |
 
 These Docker Compose files are meant for standing up this application and the required database only. If you want to stand up the entire system, [follow these instructions](../README.md#running-locally-via-docker-compose).
 

--- a/rest-villains/README.md
+++ b/rest-villains/README.md
@@ -64,10 +64,10 @@ Pick one of the 4 versions of the application from the table below and execute t
 
 | Description                  | Image Tag              | Docker Compose Run Command                                                      |
 |------------------------------|------------------------|---------------------------------------------------------------------------------|
-| JVM Java 11                  | `java11-latest`        | `docker-compose -f deploy/docker-compose/java11.yml up --remove-orphans`        |
-| JVM Java 17                  | `java17-latest`        | `docker-compose -f deploy/docker-compose/java17.yml up --remove-orphans`        |
-| Native compiled with Java 11 | `native-java11-latest` | `docker-compose -f deploy/docker-compose/native-java11.yml up --remove-orphans` |
-| Native compiled with Java 17 | `native-java17-latest` | `docker-compose -f deploy/docker-compose/native-java17.yml up --remove-orphans` |
+| JVM Java 11                  | `java11-latest`        | `docker compose -f deploy/docker-compose/java11.yml up --remove-orphans`        |
+| JVM Java 17                  | `java17-latest`        | `docker compose -f deploy/docker-compose/java17.yml up --remove-orphans`        |
+| Native compiled with Java 11 | `native-java11-latest` | `docker compose -f deploy/docker-compose/native-java11.yml up --remove-orphans` |
+| Native compiled with Java 17 | `native-java17-latest` | `docker compose -f deploy/docker-compose/native-java17.yml up --remove-orphans` |
 
 These Docker Compose files are meant for standing up this application and the required database only. If you want to stand up the entire system, [follow these instructions](../README.md#running-locally-via-docker-compose).
 


### PR DESCRIPTION
Now `compose` is built in the `docker` command. It's preferred to use it as `docker-compose` will eventually be removed