### PR TITLE
Event stats - send last event upon websocket sucscription

### DIFF
--- a/event-statistics/src/main/java/io/quarkus/sample/superheroes/statistics/endpoint/EventStatsWebSocket.java
+++ b/event-statistics/src/main/java/io/quarkus/sample/superheroes/statistics/endpoint/EventStatsWebSocket.java
@@ -1,0 +1,90 @@
+package io.quarkus.sample.superheroes.statistics.endpoint;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import javax.websocket.CloseReason;
+import javax.websocket.CloseReason.CloseCodes;
+import javax.websocket.OnClose;
+import javax.websocket.OnOpen;
+import javax.websocket.Session;
+
+import org.jboss.logging.Logger;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.subscription.Cancellable;
+import io.smallrye.mutiny.unchecked.Unchecked;
+
+/**
+ * Base WebSocket endpoint which handles caching the stream and replaying
+ * the last event from a stream upon subscription by new socket clients
+ * @param <V> The object type inside each event
+ */
+public abstract class EventStatsWebSocket<V> {
+  private final ConcurrentMap<Session, Cancellable> sessions = new ConcurrentHashMap<>();
+  private Multi<String> cachedStream;
+  private Logger logger;
+
+  @Inject
+  ObjectMapper mapper;
+
+  protected abstract Multi<V> getStream();
+
+  @OnOpen
+  public void onOpen(Session session) {
+    this.logger.debugf("Opening session with id %s", session.getId());
+    this.sessions.put(session, createSubscription(session));
+  }
+
+  @OnClose
+  public void onClose(Session session) {
+    this.logger.debugf("Closing session with id %s", session.getId());
+    Optional.ofNullable(this.sessions.remove(session))
+      .ifPresent(Cancellable::cancel);
+  }
+
+  @PostConstruct
+  public void initialize() {
+    this.logger = Logger.getLogger(getClass());
+    this.cachedStream = Multi.createBy().replaying().upTo(1).ofMulti(getStream())
+      .map(Unchecked.function(this.mapper::writeValueAsString));
+  }
+
+  @PreDestroy
+  public void cleanup() {
+    this.sessions.forEach((session, subscription) -> {
+      subscription.cancel();
+
+      if (session.isOpen()) {
+        try {
+          session.close(new CloseReason(CloseCodes.GOING_AWAY, "Server shutting down"));
+        }
+        catch (IOException ex) {
+          this.logger.errorf(ex, "Got exception (%s) while closing session", ex.getClass().getName());
+        }
+      }
+    });
+  }
+
+  private Cancellable createSubscription(Session session) {
+    return Optional.ofNullable(this.cachedStream)
+      .orElseThrow(() -> new IllegalArgumentException("Cached stream (Multi<String>) has not been created. Please initialize it inside an @PostConstruct method."))
+      .subscribe().with(serialized -> write(session, serialized));
+  }
+
+  private void write(Session session, String text) {
+    this.logger.infof("[Session %s] - Writing message %s", session.getId(), text);
+
+    session.getAsyncRemote().sendText(text, result -> {
+      if (result.getException() != null) {
+        this.logger.error("Unable to write message to web socket", result.getException());
+      }
+    });
+  }
+}

--- a/event-statistics/src/main/java/io/quarkus/sample/superheroes/statistics/endpoint/TeamStatsWebSocket.java
+++ b/event-statistics/src/main/java/io/quarkus/sample/superheroes/statistics/endpoint/TeamStatsWebSocket.java
@@ -1,22 +1,12 @@
 package io.quarkus.sample.superheroes.statistics.endpoint;
 
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
-
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import javax.websocket.OnClose;
-import javax.websocket.OnOpen;
-import javax.websocket.Session;
 import javax.websocket.server.ServerEndpoint;
 
-import io.quarkus.logging.Log;
+import io.quarkus.sample.superheroes.statistics.domain.TeamScore;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.smallrye.mutiny.subscription.Cancellable;
-import io.smallrye.mutiny.unchecked.Unchecked;
+import io.smallrye.mutiny.Multi;
 
 /**
  * WebSocket endpoint for the {@code /stats/team} endpoint. Exposes the {@code team-stats} channel over the socket to anyone listening.
@@ -27,45 +17,12 @@ import io.smallrye.mutiny.unchecked.Unchecked;
  */
 @ServerEndpoint("/stats/team")
 @ApplicationScoped
-public class TeamStatsWebSocket {
-	private final List<Session> sessions = new CopyOnWriteArrayList<>();
-	private Cancellable cancellable;
-
-  @Inject
-  ObjectMapper mapper;
-
+public class TeamStatsWebSocket extends EventStatsWebSocket<TeamScore> {
 	@Inject
 	TeamStatsChannelHolder teamStatsChannelHolder;
 
-  @OnOpen
-	public void onOpen(Session session) {
-		this.sessions.add(session);
-	}
-
-	@OnClose
-	public void onClose(Session session) {
-		this.sessions.remove(session);
-	}
-
-	@PostConstruct
-	public void subscribe() {
-		this.cancellable = this.teamStatsChannelHolder.getTeamStats()
-      .map(Unchecked.function(this.mapper::writeValueAsString))
-      .subscribe().with(serialized -> this.sessions.forEach(session -> write(session, serialized)));
-	}
-
-	@PreDestroy
-	public void cleanup() {
-		this.cancellable.cancel();
-	}
-
-	private void write(Session session, String text) {
-		Log.infof("Writing message %s", text);
-
-		session.getAsyncRemote().sendText(text, result -> {
-			if (result.getException() != null) {
-				Log.error("Unable to write message to web socket", result.getException());
-			}
-		});
-	}
+  @Override
+  protected Multi<TeamScore> getStream() {
+    return this.teamStatsChannelHolder.getTeamStats();
+  }
 }

--- a/event-statistics/src/main/java/io/quarkus/sample/superheroes/statistics/endpoint/TopWinnerWebSocket.java
+++ b/event-statistics/src/main/java/io/quarkus/sample/superheroes/statistics/endpoint/TopWinnerWebSocket.java
@@ -1,21 +1,11 @@
 package io.quarkus.sample.superheroes.statistics.endpoint;
 
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
-
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
 import javax.enterprise.context.ApplicationScoped;
-import javax.websocket.OnClose;
-import javax.websocket.OnOpen;
-import javax.websocket.Session;
 import javax.websocket.server.ServerEndpoint;
 
-import io.quarkus.logging.Log;
+import io.quarkus.sample.superheroes.statistics.domain.Score;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.smallrye.mutiny.subscription.Cancellable;
-import io.smallrye.mutiny.unchecked.Unchecked;
+import io.smallrye.mutiny.Multi;
 
 /**
  * WebSocket endpoint for the {@code /stats/winners} endpoint. Exposes the {@code winner-stats} channel over the socket to anyone listening.
@@ -26,48 +16,15 @@ import io.smallrye.mutiny.unchecked.Unchecked;
  */
 @ServerEndpoint("/stats/winners")
 @ApplicationScoped
-public class TopWinnerWebSocket {
-	private final ObjectMapper mapper;
+public class TopWinnerWebSocket extends EventStatsWebSocket<Iterable<Score>> {
 	private final TopWinnerStatsChannelHolder topWinnerStatsChannelHolder;
-	private final List<Session> sessions = new CopyOnWriteArrayList<>();
-	private Cancellable cancellable;
 
-	public TopWinnerWebSocket(ObjectMapper mapper, TopWinnerStatsChannelHolder topWinnerStatsChannelHolder) {
-		this.mapper = mapper;
+	public TopWinnerWebSocket(TopWinnerStatsChannelHolder topWinnerStatsChannelHolder) {
 		this.topWinnerStatsChannelHolder = topWinnerStatsChannelHolder;
 	}
 
-	@OnOpen
-	public void onOpen(Session session) {
-		this.sessions.add(session);
-	}
-
-	@OnClose
-	public void onClose(Session session) {
-		this.sessions.remove(session);
-	}
-
-	@PostConstruct
-	public void subscribe() {
-		this.cancellable = this.topWinnerStatsChannelHolder.getWinners()
-			.map(Unchecked.function(this.mapper::writeValueAsString))
-			.subscribe().with(serialized -> this.sessions.forEach(session -> write(session, serialized)));
-	}
-
-	@PreDestroy
-	public void cleanup() {
-		this.cancellable.cancel();
-	}
-
-	private void write(Session session, String text) {
-		Log.infof("Writing message %s", text);
-
-		session.getAsyncRemote().sendText(text, result -> {
-			var ex = result.getException();
-
-			if (ex != null) {
-				Log.error("Unable to write message to web socket", ex);
-			}
-		});
-	}
+  @Override
+  protected Multi<Iterable<Score>> getStream() {
+    return this.topWinnerStatsChannelHolder.getWinners();
+  }
 }

--- a/event-statistics/src/main/resources/application.properties
+++ b/event-statistics/src/main/resources/application.properties
@@ -11,6 +11,9 @@ mp.messaging.incoming.fights.auto.offset.reset=earliest
 mp.messaging.incoming.fights.broadcast=true
 mp.messaging.incoming.fights.enable.auto.commit=false
 
+## Dev configuration
+%dev.quarkus.log.category."io.quarkus.sample.superheroes.statistics".level=DEBUG
+
 ## Test configuration
 %test.quarkus.log.category."io.quarkus.sample.superheroes.statistics".level=DEBUG
 


### PR DESCRIPTION
Currently in the event statistics service when a websocket connects, no data is sent back to the websocket until the next event is received from Kafka.

This is because the subscription to the stream happens only once in the websocket class. As events are received, the open websocket sessions at that point in time are iterated and the event pushed to those websockets.

This change makes it so that a new websocket connection will receive the last event that was received so that it can properly populate the dashboard. To do that, each websocket session connection needs its own subscription so that it can replay the last event from the stream prior to its subscription.

As part of this I refactored the majority of the WebSocket classes into a single abstract base class which is then extended by each websocket class. All the subscription/caching of the stream/replay/etc is encapsulated in that single base class.