### PR TITLE
Create multi-arch images

### DIFF
--- a/.github/workflows/build-push-container-images.yml
+++ b/.github/workflows/build-push-container-images.yml
@@ -2,7 +2,9 @@ name: Build and Push Container images
 
 env:
   IMAGE_BASE_NAME: "quay.io/quarkus-super-heroes"
-  MANDREL_VERSION: "22.0.0.2-Final"
+  MANDREL_IMAGE: "quay.io/quarkus/ubi-quarkus-mandrel"
+  MANDREL_VERSION: "22.0"
+  LATEST_IMAGE_TAG: "latest"
 
 on:
   workflow_run:
@@ -19,11 +21,10 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build-test-jvm-images:
+  build-jvm-images:
     if: ((github.event_name == 'workflow_dispatch') || ((github.event_name == 'workflow_run') && ((github.event.workflow_run.event == 'push') || (github.event.workflow_run.event == 'workflow_dispatch')) && (github.event.workflow_run.conclusion == 'success'))) && ((github.repository == 'quarkusio/quarkus-super-heroes') && (github.ref == 'refs/heads/main'))
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
       matrix:
         java:
           - '11'
@@ -33,7 +34,10 @@ jobs:
           - rest-fights
           - rest-heroes
           - rest-villains
-    name: "build-test-jvm-${{ matrix.project }}-java-${{ matrix.java }}"
+        arch:
+          - amd64
+          - arm64
+    name: "Build JVM images (${{ matrix.arch}}-${{ matrix.project }}-java${{ matrix.java }})"
     steps:
       - uses: actions/checkout@v3
 
@@ -49,37 +53,47 @@ jobs:
         run: |
           echo "QUARKUS_VERSION=$(./mvnw help:evaluate -Dexpression=quarkus.platform.version -q -DforceStdout)" >> $GITHUB_ENV &&
           echo "APP_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV &&
-          if [[ ${{ matrix.java }} == '11' ]]; then 
-            echo "JVM_DOCKERFILE=Dockerfile.jvm" >> "$GITHUB_ENV" 
+          if [[ ${{ matrix.java }} == '11' ]]; then
+            echo "JVM_DOCKERFILE=Dockerfile.jvm" >> "$GITHUB_ENV"
           else
             echo "JVM_DOCKERFILE=Dockerfile.jvm${{ matrix.java }}" >> "$GITHUB_ENV"
           fi
 
       - name: Create container tags
         working-directory: ${{ matrix.project }}
-        run: |
-          echo "CONTAINER_TAG=${{ env.APP_VERSION }}-quarkus-${{ env.QUARKUS_VERSION }}-java${{ matrix.java }}" >> $GITHUB_ENV &&
-          echo "ADDITIONAL_TAG=java${{ matrix.java }}-latest" >> $GITHUB_ENV
+        run: echo "CONTAINER_TAG=${{ env.APP_VERSION }}-quarkus-${{ env.QUARKUS_VERSION }}-java${{ matrix.java }}" >> $GITHUB_ENV
 
-      - name: "create-test-jvm-image-${{ matrix.project }}-java-${{ matrix.java }}"
+      - name: Build app (${{ matrix.project }}-java${{ matrix.java }}-${{ matrix.arch}})
         working-directory: ${{ matrix.project }}
-        run: |
-          #          ./mvnw verify \
-          ./mvnw clean package -DskipTests \
-            -Dmaven.compiler.release=${{ matrix.java }} \
-            -Dquarkus.http.host=0.0.0.0 \
-            -Dquarkus.docker.dockerfile-jvm-path=src/main/docker/${{ env.JVM_DOCKERFILE }} \
-            -Dquarkus.container-image.build=true \
-            -Dquarkus.container-image.push=false \
-            -Dquarkus.container-image.tag=${{ env.CONTAINER_TAG }} \
-            -Dquarkus.container-image.additional-tags=${{ env.ADDITIONAL_TAG }}
+        run: ./mvnw -B clean package -DskipTests -Dmaven.compiler.release=${{ matrix.java }} -Dquarkus.http.host=0.0.0.0
 
-      - name: "save-jvm-image-${{ matrix.project }}-java-${{ matrix.java }}"
+      - name: Set up QEMU
+        if: matrix.arch == 'arm64'
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          install: true
+
+      - name: Build JVM image (${{ matrix.project }}-java${{ matrix.java }}-${{ matrix.arch}})
+        uses: docker/build-push-action@v3
+        with:
+          context: ${{ matrix.project }}
+          platforms: linux/${{ matrix.arch }}
+          push: false
+          load: true
+          file: ${{ matrix.project }}/src/main/docker/${{ env.JVM_DOCKERFILE }}
+          tags: ${{ env.IMAGE_BASE_NAME }}/${{ matrix.project }}:${{ env.CONTAINER_TAG }}-${{ matrix.arch }}
+
+      - name: Save JVM Image (${{ matrix.project }}-java${{ matrix.java }}-${{ matrix.arch }})
         uses: ishworkh/docker-image-artifact-upload@v1
         with:
-          image: "${{ env.IMAGE_BASE_NAME }}/${{ matrix.project }}:${{ env.CONTAINER_TAG }}"
+          image: "${{ env.IMAGE_BASE_NAME }}/${{ matrix.project }}:${{ env.CONTAINER_TAG }}-${{ matrix.arch }}"
 
-  build-test-native-images:
+  build-native-images:
     if: ((github.event_name == 'workflow_dispatch') || ((github.event_name == 'workflow_run') && ((github.event.workflow_run.event == 'push') || (github.event.workflow_run.event == 'workflow_dispatch')) && (github.event.workflow_run.conclusion == 'success'))) && ((github.repository == 'quarkusio/quarkus-super-heroes') && (github.ref == 'refs/heads/main'))
     runs-on: ubuntu-latest
     strategy:
@@ -93,37 +107,19 @@ jobs:
           - rest-fights
           - rest-heroes
           - rest-villains
-    name: "build-test-native-${{ matrix.project }}-java-${{ matrix.java }}"
+        arch:
+          - amd64
+    #          - arm64
+    name: "Build Native images (${{ matrix.arch}}-${{ matrix.project }}-java${{ matrix.java }})"
     steps:
       - uses: actions/checkout@v3
 
-      - name: Cache and restore Maven artifacts
-        id: check-mvn-cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: setup-java-${{ runner.os }}-maven-${{ hashFiles('${{ matrix.project }}/pom.xml') }}
-
-      - name: Cache and restore Mandrel distro
-        id: check-mandrel-cache
-        uses: actions/cache@v3
-        with:
-          path: java_package-${{ matrix.java }}.tar.gz
-          key: mandrel-distro-${{ env.MANDREL_VERSION }}-${{ matrix.java }}
-
-      - name: Download Mandrel
-        if: steps.check-mandrel-cache.outputs.cache-hit != 'true'
-        run: |
-          download_url="https://github.com/graalvm/mandrel/releases/download/mandrel-${MANDREL_VERSION}/mandrel-java${{ matrix.java }}-linux-amd64-${MANDREL_VERSION}.tar.gz"
-          wget -q -O java_package-${{ matrix.java }}.tar.gz $download_url
-
-      - name: Setup Maven+OpenJDK Distro
+      - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          distribution: 'jdkfile'
-          jdkFile: java_package-${{ matrix.java }}.tar.gz
           java-version: ${{ matrix.java }}
-          architecture: x64
+          distribution: temurin
+          cache: maven
 
       - name: Create env vars
         working-directory: ${{ matrix.project }}
@@ -133,68 +129,69 @@ jobs:
 
       - name: Create container tags
         working-directory: ${{ matrix.project }}
-        run: |
-          echo "CONTAINER_TAG=${{ env.APP_VERSION }}-quarkus-${{ env.QUARKUS_VERSION }}-native-java${{ matrix.java }}" >> $GITHUB_ENV && \
-          echo "ADDITIONAL_TAG=native-java${{ matrix.java }}-latest" >> $GITHUB_ENV
+        run: echo "CONTAINER_TAG=${{ env.APP_VERSION }}-quarkus-${{ env.QUARKUS_VERSION }}-native-java${{ matrix.java }}" >> $GITHUB_ENV
 
-      - name: "build-test-native-image-${{ matrix.project }}-java-${{ matrix.java }}"
+      - name: Build native image (${{ matrix.project }}-java${{ matrix.java }}-${{ matrix.arch}})
         working-directory: ${{ matrix.project }}
         run: |
-          ./mvnw -B clean verify -Pnative \
-            -Dquarkus.http.host=0.0.0.0 \
-            -Dmaven.compiler.release=${{ matrix.java }}
-
-      - name: "build-native-container-${{ matrix.project }}-java-${{ matrix.java }}"
-        working-directory: ${{ matrix.project }}
-        run: |
-          ./mvnw -B package -DskipTests -Pnative \
+          ./mvnw -B clean package -DskipTests -Pnative \
             -Dmaven.compiler.release=${{ matrix.java }} \
             -Dquarkus.http.host=0.0.0.0 \
             -Dquarkus.native.container-build=true \
-            -Dquarkus.native.reuse-existing=true \
-            -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:22.0-java${{ matrix.java }} \
+            -Dquarkus.native.builder-image=${{ env.MANDREL_IMAGE }}:${{ env.MANDREL_VERSION }}-java${{ matrix.java }} \
             -Dquarkus.container-image.build=true \
             -Dquarkus.container-image.push=false \
-            -Dquarkus.container-image.tag=${{ env.CONTAINER_TAG }} \
-            -Dquarkus.container-image.additional-tags=${{ env.ADDITIONAL_TAG }}
+            -Dquarkus.container-image.tag=${{ env.CONTAINER_TAG }}-${{ matrix.arch }}
 
-      - name: "save-native-image-${{ matrix.project }}-java-${{ matrix.java }}"
+      - name: Save native Image (${{ matrix.project }}-java${{ matrix.java }}-${{ matrix.arch }})
         uses: ishworkh/docker-image-artifact-upload@v1
         with:
-          image: "${{ env.IMAGE_BASE_NAME }}/${{ matrix.project }}:${{ env.CONTAINER_TAG }}"
+          image: "${{ env.IMAGE_BASE_NAME }}/${{ matrix.project }}:${{ env.CONTAINER_TAG }}-${{ matrix.arch }}"
 
-  build-ui-image:
+  build-ui-images:
     if: ((github.event_name == 'workflow_dispatch') || ((github.event_name == 'workflow_run') && ((github.event.workflow_run.event == 'push') || (github.event.workflow_run.event == 'workflow_dispatch')) && (github.event.workflow_run.conclusion == 'success'))) && ((github.repository == 'quarkusio/quarkus-super-heroes') && (github.ref == 'refs/heads/main'))
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch:
+          - amd64
+          - arm64
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        if: matrix.arch == 'arm64'
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          install: true
 
-      - name: Build UI image
+      - name: Build UI image (${{ matrix.arch }})
         uses: docker/build-push-action@v3
         with:
           context: ui-super-heroes
+          platforms: linux/${{ matrix.arch }}
           push: false
           load: true
-          tags: ${{ env.IMAGE_BASE_NAME }}/ui-super-heroes:latest
+          tags: ${{ env.IMAGE_BASE_NAME }}/ui-super-heroes:${{ env.LATEST_IMAGE_TAG }}-${{ matrix.arch }}
 
-      - name: Save UI image
+      - name: Save UI image (${{ matrix.arch }})
         uses: ishworkh/docker-image-artifact-upload@v1
         with:
-          image: "${{ env.IMAGE_BASE_NAME }}/ui-super-heroes:latest"
+          image: "${{ env.IMAGE_BASE_NAME }}/ui-super-heroes:${{ env.LATEST_IMAGE_TAG }}-${{ matrix.arch }}"
 
   push-app-images:
     if: ((github.event_name == 'workflow_dispatch') || ((github.event_name == 'workflow_run') && ((github.event.workflow_run.event == 'push') || (github.event.workflow_run.event == 'workflow_dispatch')) && (github.event.workflow_run.conclusion == 'success'))) && ((github.repository == 'quarkusio/quarkus-super-heroes') && (github.ref == 'refs/heads/main'))
     needs:
-      - build-test-jvm-images
-      - build-test-native-images
-      - build-ui-image
+      - build-jvm-images
+      - build-native-images
+      - build-ui-images
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
         java:
           - '11'
@@ -207,7 +204,124 @@ jobs:
           - rest-fights
           - rest-heroes
           - rest-villains
-    name: "push-app-images-${{ matrix.project }}-${{ matrix.kind }}java-${{ matrix.java }}"
+        arch:
+          - amd64
+          - arm64
+    name: "Push app images (${{ matrix.arch}}-${{ matrix.project }}-${{ matrix.kind }}java${{ matrix.java }})"
+    steps:
+      - uses: actions/checkout@v3
+        if: ((matrix.arch == 'amd64') || (matrix.kind != 'native-'))
+
+      - name: Setup Java
+        if: ((matrix.arch == 'amd64') || (matrix.kind != 'native-'))
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: temurin
+          cache: maven
+
+      - name: Create env vars
+        if: ((matrix.arch == 'amd64') || (matrix.kind != 'native-'))
+        working-directory: ${{ matrix.project }}
+        run: |
+          echo "QUARKUS_VERSION=$(./mvnw help:evaluate -Dexpression=quarkus.platform.version -q -DforceStdout)" >> $GITHUB_ENV &&
+          echo "APP_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
+
+      - name: Create container tags
+        if: ((matrix.arch == 'amd64') || (matrix.kind != 'native-'))
+        working-directory: ${{ matrix.project }}
+        run: |
+          echo "CONTAINER_TAG=${{ env.APP_VERSION }}-quarkus-${{ env.QUARKUS_VERSION }}-${{ matrix.kind }}java${{ matrix.java }}" >> $GITHUB_ENV &&
+          echo "ADDITIONAL_TAG=${{ matrix.kind }}java${{ matrix.java }}-${{ env.LATEST_IMAGE_TAG }}" >> $GITHUB_ENV
+
+      - name: Get saved images (${{ matrix.project }}-${{ matrix.kind }}java${{ matrix.java }}-${{ matrix.arch }})
+        if: ((matrix.arch == 'amd64') || (matrix.kind != 'native-'))
+        uses: ishworkh/docker-image-artifact-download@v1
+        with:
+          image: "${{ env.IMAGE_BASE_NAME }}/${{ matrix.project }}:${{ env.CONTAINER_TAG }}-${{ matrix.arch }}"
+
+      - name: Login to quay
+        if: ((matrix.arch == 'amd64') || (matrix.kind != 'native-'))
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_REPO_USERNAME }}
+          password: ${{ secrets.QUAY_REPO_TOKEN }}
+
+      - name: Tag image
+        if: ((matrix.arch == 'amd64') || (matrix.kind != 'native-'))
+        working-directory: ${{ matrix.project }}
+        run: "docker tag ${{ env.IMAGE_BASE_NAME }}/${{ matrix.project }}:${{ env.CONTAINER_TAG }}-${{ matrix.arch }} ${{ env.IMAGE_BASE_NAME }}/${{ matrix.project }}:${{ env.ADDITIONAL_TAG }}-${{ matrix.arch }}"
+
+      - name: Push images
+        if: ((matrix.arch == 'amd64') || (matrix.kind != 'native-'))
+        working-directory: ${{ matrix.project }}
+        run: "docker push -a ${{ env.IMAGE_BASE_NAME }}/${{ matrix.project }}"
+
+  push-ui-images:
+    if: ((github.event_name == 'workflow_dispatch') || ((github.event_name == 'workflow_run') && ((github.event.workflow_run.event == 'push') || (github.event.workflow_run.event == 'workflow_dispatch')) && (github.event.workflow_run.conclusion == 'success'))) && ((github.repository == 'quarkusio/quarkus-super-heroes') && (github.ref == 'refs/heads/main'))
+    needs:
+      - build-jvm-images
+      - build-native-images
+      - build-ui-images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch:
+          - amd64
+          - arm64
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: temurin
+          cache: maven
+
+      - name: Create env vars
+        working-directory: ui-super-heroes
+        run: echo "APP_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
+
+      - name: Get Saved UI Image (${{ matrix.arch }})
+        uses: ishworkh/docker-image-artifact-download@v1
+        with:
+          image: "${{ env.IMAGE_BASE_NAME }}/ui-super-heroes:${{ env.LATEST_IMAGE_TAG }}-${{ matrix.arch }}"
+
+      - name: Login to quay
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_REPO_USERNAME }}
+          password: ${{ secrets.QUAY_REPO_TOKEN }}
+
+      - name: Tag UI image (${{ matrix.arch }})
+        working-directory: ui-super-heroes
+        run: docker tag ${{ env.IMAGE_BASE_NAME }}/ui-super-heroes:${{ env.LATEST_IMAGE_TAG }}-${{ matrix.arch }} ${{ env.IMAGE_BASE_NAME }}/ui-super-heroes:${{ env.APP_VERSION }}-${{ matrix.arch }}
+
+      - name: Push UI image (${{ matrix.arch }})
+        working-directory: ui-super-heroes
+        run: "docker push -a ${{ env.IMAGE_BASE_NAME }}/ui-super-heroes"
+
+  create-app-multiarch-manifests:
+    if: ((github.event_name == 'workflow_dispatch') || ((github.event_name == 'workflow_run') && ((github.event.workflow_run.event == 'push') || (github.event.workflow_run.event == 'workflow_dispatch')) && (github.event.workflow_run.conclusion == 'success'))) && ((github.repository == 'quarkusio/quarkus-super-heroes') && (github.ref == 'refs/heads/main'))
+    needs: push-app-images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java:
+          - '11'
+          - '17'
+        kind:
+          - ""
+          - "native-"
+        project:
+          - event-statistics
+          - rest-fights
+          - rest-heroes
+          - rest-villains
+    name: Create app multiarch manifests (${{ matrix.project }}-${{ matrix.kind }}java${{ matrix.java }})
     steps:
       - uses: actions/checkout@v3
 
@@ -228,12 +342,7 @@ jobs:
         working-directory: ${{ matrix.project }}
         run: |
           echo "CONTAINER_TAG=${{ env.APP_VERSION }}-quarkus-${{ env.QUARKUS_VERSION }}-${{ matrix.kind }}java${{ matrix.java }}" >> $GITHUB_ENV &&
-          echo "ADDITIONAL_TAG=${{ matrix.kind }}java${{ matrix.java }}-latest" >> $GITHUB_ENV
-
-      - name: "get-saved-image-${{ matrix.project }}-${{ matrix.kind }}java-${{ matrix.java }}"
-        uses: ishworkh/docker-image-artifact-download@v1
-        with:
-          image: "${{ env.IMAGE_BASE_NAME }}/${{ matrix.project }}:${{ env.CONTAINER_TAG }}"
+          echo "ADDITIONAL_TAG=${{ matrix.kind }}java${{ matrix.java }}-${{ env.LATEST_IMAGE_TAG }}" >> $GITHUB_ENV
 
       - name: Login to quay
         uses: docker/login-action@v2
@@ -242,20 +351,33 @@ jobs:
           username: ${{ secrets.QUAY_REPO_USERNAME }}
           password: ${{ secrets.QUAY_REPO_TOKEN }}
 
-      - name: Tag image
-        working-directory: ${{ matrix.project }}
-        run: "docker tag ${{ env.IMAGE_BASE_NAME }}/${{ matrix.project }}:${{ env.CONTAINER_TAG }} ${{ env.IMAGE_BASE_NAME }}/${{ matrix.project }}:${{ env.ADDITIONAL_TAG }}"
+      - name: Create and push multi-arch JVM manifests
+        if: matrix.kind != 'native-'
+        shell: bash
+        run: |
+          docker manifest create ${{ env.IMAGE_BASE_NAME }}/${{ matrix.project }}:${{ env.CONTAINER_TAG }} \
+            -a ${{ env.IMAGE_BASE_NAME }}/${{ matrix.project }}:${{ env.CONTAINER_TAG }}-amd64 \
+            -a ${{ env.IMAGE_BASE_NAME }}/${{ matrix.project }}:${{ env.CONTAINER_TAG }}-arm64
+          docker manifest push ${{ env.IMAGE_BASE_NAME }}/${{ matrix.project }}:${{ env.CONTAINER_TAG }}
+          docker manifest create ${{ env.IMAGE_BASE_NAME }}/${{ matrix.project }}:${{ env.ADDITIONAL_TAG }} \
+            -a ${{ env.IMAGE_BASE_NAME }}/${{ matrix.project }}:${{ env.ADDITIONAL_TAG }}-amd64 \
+            -a ${{ env.IMAGE_BASE_NAME }}/${{ matrix.project }}:${{ env.ADDITIONAL_TAG }}-arm64
+          docker manifest push ${{ env.IMAGE_BASE_NAME }}/${{ matrix.project }}:${{ env.ADDITIONAL_TAG }}
 
-      - name: Push images in ${{ matrix.project }}
-        working-directory: ${{ matrix.project }}
-        run: "docker push -a ${{ env.IMAGE_BASE_NAME }}/${{ matrix.project }}"
+      - name: Create and push single-arch native manifests
+        if: matrix.kind == 'native-'
+        shell: bash
+        run: |
+          docker manifest create ${{ env.IMAGE_BASE_NAME }}/${{ matrix.project }}:${{ env.CONTAINER_TAG }} \
+            -a ${{ env.IMAGE_BASE_NAME }}/${{ matrix.project }}:${{ env.CONTAINER_TAG }}-amd64
+          docker manifest push ${{ env.IMAGE_BASE_NAME }}/${{ matrix.project }}:${{ env.CONTAINER_TAG }}
+          docker manifest create ${{ env.IMAGE_BASE_NAME }}/${{ matrix.project }}:${{ env.ADDITIONAL_TAG }} \
+            -a ${{ env.IMAGE_BASE_NAME }}/${{ matrix.project }}:${{ env.ADDITIONAL_TAG }}-amd64
+          docker manifest push ${{ env.IMAGE_BASE_NAME }}/${{ matrix.project }}:${{ env.ADDITIONAL_TAG }}
 
-  push-ui-image:
+  create-ui-multiarch-manifests:
     if: ((github.event_name == 'workflow_dispatch') || ((github.event_name == 'workflow_run') && ((github.event.workflow_run.event == 'push') || (github.event.workflow_run.event == 'workflow_dispatch')) && (github.event.workflow_run.conclusion == 'success'))) && ((github.repository == 'quarkusio/quarkus-super-heroes') && (github.ref == 'refs/heads/main'))
-    needs:
-      - build-test-jvm-images
-      - build-test-native-images
-      - build-ui-image
+    needs: push-ui-images
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -271,11 +393,6 @@ jobs:
         working-directory: ui-super-heroes
         run: echo "APP_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
 
-      - name: Get Saved UI Image
-        uses: ishworkh/docker-image-artifact-download@v1
-        with:
-          image: "${{ env.IMAGE_BASE_NAME }}/ui-super-heroes:latest"
-
       - name: Login to quay
         uses: docker/login-action@v2
         with:
@@ -283,19 +400,23 @@ jobs:
           username: ${{ secrets.QUAY_REPO_USERNAME }}
           password: ${{ secrets.QUAY_REPO_TOKEN }}
 
-      - name: Tag UI image
-        working-directory: ui-super-heroes
-        run: "docker tag ${{ env.IMAGE_BASE_NAME }}/ui-super-heroes:latest ${{ env.IMAGE_BASE_NAME }}/ui-super-heroes:${{ env.APP_VERSION }}"
-
-      - name: Push UI image
-        working-directory: ui-super-heroes
-        run: "docker push -a ${{ env.IMAGE_BASE_NAME }}/ui-super-heroes"
+      - name: Create and push multi-arch manifests
+        shell: bash
+        run: |
+          docker manifest create ${{ env.IMAGE_BASE_NAME }}/ui-super-heroes:${{ env.LATEST_IMAGE_TAG }} \
+            -a ${{ env.IMAGE_BASE_NAME }}/ui-super-heroes:${{ env.LATEST_IMAGE_TAG }}-amd64 \
+            -a ${{ env.IMAGE_BASE_NAME }}/ui-super-heroes:${{ env.LATEST_IMAGE_TAG }}-arm64
+          docker manifest push ${{ env.IMAGE_BASE_NAME }}/ui-super-heroes:${{ env.LATEST_IMAGE_TAG }}
+          docker manifest create ${{ env.IMAGE_BASE_NAME }}/ui-super-heroes:${{ env.APP_VERSION }} \
+            -a ${{ env.IMAGE_BASE_NAME }}/ui-super-heroes:${{ env.APP_VERSION }}-amd64 \
+            -a ${{ env.IMAGE_BASE_NAME }}/ui-super-heroes:${{ env.APP_VERSION }}-arm64
+          docker manifest push ${{ env.IMAGE_BASE_NAME }}/ui-super-heroes:${{ env.APP_VERSION }}
 
   cleanup-artifacts:
     needs:
-      - push-app-images
-      - push-ui-image
-    if: success() || failure()
+      - create-app-multiarch-manifests
+      - create-ui-multiarch-manifests
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Delete artifacts


### PR DESCRIPTION
Create multi-arch images.

So far I haven't been able to build arm64 native images, but with this there are now both arm64 & amd64 images for the `ui-super-heroes` app as well as for the JVM images of the Quarkus services.

Fixes #70