### PR TITLE
Adding profile-based configuration for local deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Deployment descriptors for these images are provided in the [`deploy/k8s`](deplo
 
 The only real difference between the Minikube and Kubernetes descriptors is that all the application `Service`s in the Minikube descriptors use `type: NodePort` so that a list of all the applications can be obtained simply by running `minikube service list`.
 
+> **NOTE:** If you'd like to deploy each application directly from source to Kubernetes, please follow the guide located within each application's folder (i.e. [`event-statistics`](event-statistics/README.md#deploying-directly-via-kubernetes-extensions), [`rest-fights`](rest-fights/README.md#deploying-directly-via-kubernetes-extensions), [`rest-heroes`](rest-heroes/README.md#deploying-directly-via-kubernetes-extensions), [`rest-villains`](rest-villains/README.md#deploying-directly-via-kubernetes-extensions)).
+
 ### Routing
 Both the Minikube and Kubernetes descriptors also assume there is an [Ingress Controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/) installed and configured. There is a single `Ingress` in the Minikube and Kubernetes descriptors denoting `/` and `/api/fights` paths. You may need to add/update the `host` field in the `Ingress` as well in order for things to work.
 

--- a/event-statistics/README.md
+++ b/event-statistics/README.md
@@ -121,6 +121,23 @@ The application is exposed outside of the cluster on port `80`.
 These are only the descriptors for this application and the required Kafka broker and Apicurio Schema Registry only. If you want to deploy the entire system, [follow these instructions](../README.md#deploying-to-kubernetes).
 
 ### Deploying directly via Kubernetes Extensions
-Following the [deployment section](https://quarkus.io/guides/deploying-to-kubernetes#deployment) of the [Quarkus Kubernetes Extension Guide](https://quarkus.io/guides/deploying-to-kubernetes) (or the [deployment section](https://quarkus.io/guides/deploying-to-openshift#build-and-deployment) of the [Quarkus OpenShift Extension Guide](https://quarkus.io/guides/deploying-to-openshift) if deploying to [OpenShift](https://openshift.com)), you can run `./mvnw clean package -Dquarkus.kubernetes.deploy=true` to deploy the application and any of its dependencies (see [Kubernetes (and variants) resource generation](../docs/automation.md#kubernetes-and-variants-resource-generation) of the [automation strategy document](../docs/automation.md)) to Kubernetes or OpenShift.
+Following the [deployment section](https://quarkus.io/guides/deploying-to-kubernetes#deployment) of the [Quarkus Kubernetes Extension Guide](https://quarkus.io/guides/deploying-to-kubernetes) (or the [deployment section](https://quarkus.io/guides/deploying-to-openshift#build-and-deployment) of the [Quarkus OpenShift Extension Guide](https://quarkus.io/guides/deploying-to-openshift) if deploying to [OpenShift](https://openshift.com)), you can run one of the following commands to deploy the application and any of its dependencies (see [Kubernetes (and variants) resource generation](../docs/automation.md#kubernetes-and-variants-resource-generation) of the [automation strategy document](../docs/automation.md)) to your preferred Kubernetes distribution.
 
-You may need to adjust some of the other configuration options as well (see [Quarkus Kubernetes Extension configuration options](https://quarkus.io/guides/deploying-to-kubernetes#configuration-options) and [Quarkus OpenShift Extension configuration options](https://quarkus.io/guides/deploying-to-openshift#configuration-reference)). The [`do_build` function in the `generate-k8s-resources.sh` script](../scripts/generate-k8s-resources.sh) uses these extensions to generate the manifests in the [`deploy/k8s` directory](deploy/k8s).
+> **NOTE:** For non-OpenShift or minikube Kubernetes variants, you will most likely need to [push the image to a container registry](https://quarkus.io/guides/container-image#pushing) by adding the `-Dquarkus.container-image.push=true` flag, as well as setting the `quarkus.container-image.registry`, `quarkus.container-image.group`, and/or the `quarkus.container-image.name` properties to different values.
+
+| Target Platform        | Java Version | Command                                                                                                    |
+|------------------------|:------------:|------------------------------------------------------------------------------------------------------------|
+| Kubernetes             |      11      | `./mvnw clean package -Dquarkus.profile=kubernetes -Dquarkus.kubernetes.deploy=true -DskipTests`           |
+| Kubernetes             |      17      | `./mvnw clean package -Dquarkus.profile=kubernetes-17 -Dquarkus.kubernetes.deploy=true -DskipTests`        |
+| OpenShift              |      11      | `./mvnw clean package -Dquarkus.profile=openshift -Dquarkus.kubernetes.deploy=true -DskipTests`            |
+| OpenShift              |      17      | `./mvnw clean package -Dquarkus.profile=openshift-17 -Dquarkus.kubernetes.deploy=true -DskipTests`         |
+| Minikube               |      11      | `./mvnw clean package -Dquarkus.profile=minikube -Dquarkus.kubernetes.deploy=true -DskipTests`             |
+| Minikube               |      17      | `./mvnw clean package -Dquarkus.profile=minikube-17 -Dquarkus.kubernetes.deploy=true -DskipTests`          |
+| KNative                |      11      | `./mvnw clean package -Dquarkus.profile=knative -Dquarkus.kubernetes.deploy=true -DskipTests`              |
+| KNative                |      17      | `./mvnw clean package -Dquarkus.profile=knative-17 -Dquarkus.kubernetes.deploy=true -DskipTests`           |
+| KNative (on OpenShift) |      11      | `./mvnw clean package -Dquarkus.profile=knative-openshift -Dquarkus.kubernetes.deploy=true -DskipTests`    |
+| KNative (on OpenShift) |      17      | `./mvnw clean package -Dquarkus.profile=knative-openshift-17 -Dquarkus.kubernetes.deploy=true -DskipTests` |
+
+You may need to adjust other configuration options as well (see [Quarkus Kubernetes Extension configuration options](https://quarkus.io/guides/deploying-to-kubernetes#configuration-options) and [Quarkus OpenShift Extension configuration options](https://quarkus.io/guides/deploying-to-openshift#configuration-reference)).
+
+> The [`do_build` function in the `generate-k8s-resources.sh` script](../scripts/generate-k8s-resources.sh) uses these extensions to generate the manifests in the [`deploy/k8s` directory](deploy/k8s).

--- a/event-statistics/src/main/resources/application.properties
+++ b/event-statistics/src/main/resources/application.properties
@@ -22,8 +22,13 @@ quarkus.container-image.builder=docker
 quarkus.container-image.registry=quay.io
 quarkus.container-image.group=quarkus-super-heroes
 quarkus.container-image.name=${quarkus.application.name}
+paths.dockerfile.jvm-17=src/main/docker/Dockerfile.jvm17
+paths.base-image.jvm-17=registry.access.redhat.com/ubi8/openjdk-17:1.11
 
 # Kubernetes
+%kubernetes.quarkus.config.profile.parent=prod
+%kubernetes-17.quarkus.config.profile.parent=prod
+%kubernetes-17.quarkus.docker.dockerfile-jvm-path=${paths.dockerfile.jvm-17}
 quarkus.kubernetes.part-of=event-stats
 quarkus.kubernetes.annotations."app.openshift.io/connects-to"=fights-kafka,apicurio
 quarkus.kubernetes.env.configmaps=${quarkus.application.name}-config
@@ -33,6 +38,15 @@ quarkus.kubernetes.labels.application=${quarkus.kubernetes.part-of}
 quarkus.kubernetes.labels.system=quarkus-super-heroes
 
 # OpenShift
+%openshift.quarkus.config.profile.parent=prod
+%openshift.quarkus.kubernetes.deployment-target=openshift
+%openshift.quarkus.container-image.builder=openshift
+%openshift-17.quarkus.config.profile.parent=prod
+%openshift-17.quarkus.kubernetes.deployment-target=openshift
+%openshift-17.quarkus.container-image.builder=openshift
+%openshift-17.quarkus.docker.dockerfile-jvm-path=${paths.dockerfile.jvm-17}
+%openshift-17.quarkus.openshift.jvm-dockerfile=${paths.dockerfile.jvm-17}
+%openshift-17.quarkus.openshift.base-jvm-image=${paths.base-image.jvm-17}
 quarkus.openshift.part-of=${quarkus.kubernetes.part-of}
 quarkus.openshift.route.expose=true
 quarkus.openshift.annotations."app.openshift.io/connects-to"=fights-kafka,apicurio
@@ -43,6 +57,11 @@ quarkus.openshift.labels.application=${quarkus.kubernetes.labels.application}
 quarkus.openshift.labels.system=${quarkus.kubernetes.labels.system}
 
 # KNative
+%knative.quarkus.config.profile.parent=prod
+%knative.quarkus.kubernetes.deployment-target=knative
+%knative-17.quarkus.config.profile.parent=prod
+%knative-17.quarkus.kubernetes.deployment-target=knative
+%knative-17.quarkus.docker.dockerfile-jvm-path=${paths.dockerfile.jvm-17}
 quarkus.knative.part-of=${quarkus.kubernetes.part-of}
 quarkus.knative.annotations."app.openshift.io/connects-to"=fights-kafka,apicurio
 quarkus.knative.env.configmaps=${quarkus.kubernetes.env.configmaps}
@@ -50,3 +69,21 @@ quarkus.knative.env.secrets=${quarkus.kubernetes.env.secrets}
 quarkus.knative.labels.app=${quarkus.kubernetes.labels.app}
 quarkus.knative.labels.application=${quarkus.kubernetes.labels.application}
 quarkus.knative.labels.system=${quarkus.kubernetes.labels.system}
+
+# KNative on OpenShift
+%knative-openshift.quarkus.config.profile.parent=prod
+%knative-openshift.quarkus.container-image.builder=openshift
+%knative-openshift.quarkus.kubernetes.deployment-target=knative
+%knative-openshift-17.quarkus.config.profile.parent=prod
+%knative-openshift-17.quarkus.container-image.builder=openshift
+%knative-openshift-17.quarkus.kubernetes.deployment-target=knative
+%knative-openshift-17.quarkus.docker.dockerfile-jvm-path=${paths.dockerfile.jvm-17}
+%knative-openshift-17.quarkus.openshift.jvm-dockerfile=${paths.dockerfile.jvm-17}
+%knative-openshift-17.quarkus.openshift.base-jvm-image=${paths.base-image.jvm-17}
+
+# Minikube
+%minikube.quarkus.config.profile.parent=prod
+%minikube.quarkus.kubernetes.deployment-target=minikube
+%minikube-17.quarkus.config.profile.parent=prod
+%minikube-17.quarkus.kubernetes.deployment-target=minikube
+%minikube-17.quarkus.docker.dockerfile-jvm-path=${paths.dockerfile.jvm-17}

--- a/rest-fights/README.md
+++ b/rest-fights/README.md
@@ -191,6 +191,23 @@ Each application is exposed outside of the cluster on port `80`.
 If you want to deploy the entire system, [follow these instructions](../README.md#deploying-to-kubernetes).
 
 ### Deploying directly via Kubernetes Extensions
-Following the [deployment section](https://quarkus.io/guides/deploying-to-kubernetes#deployment) of the [Quarkus Kubernetes Extension Guide](https://quarkus.io/guides/deploying-to-kubernetes) (or the [deployment section](https://quarkus.io/guides/deploying-to-openshift#build-and-deployment) of the [Quarkus OpenShift Extension Guide](https://quarkus.io/guides/deploying-to-openshift) if deploying to [OpenShift](https://openshift.com)), you can run `./mvnw clean package -Dquarkus.kubernetes.deploy=true` to deploy the application and any of its dependencies (see [Kubernetes (and variants) resource generation](../docs/automation.md#kubernetes-and-variants-resource-generation) of the [automation strategy document](../docs/automation.md)) to Kubernetes or OpenShift.
+Following the [deployment section](https://quarkus.io/guides/deploying-to-kubernetes#deployment) of the [Quarkus Kubernetes Extension Guide](https://quarkus.io/guides/deploying-to-kubernetes) (or the [deployment section](https://quarkus.io/guides/deploying-to-openshift#build-and-deployment) of the [Quarkus OpenShift Extension Guide](https://quarkus.io/guides/deploying-to-openshift) if deploying to [OpenShift](https://openshift.com)), you can run one of the following commands to deploy the application and any of its dependencies (see [Kubernetes (and variants) resource generation](../docs/automation.md#kubernetes-and-variants-resource-generation) of the [automation strategy document](../docs/automation.md)) to your preferred Kubernetes distribution.
 
-You may need to adjust some of the other configuration options as well (see [Quarkus Kubernetes Extension configuration options](https://quarkus.io/guides/deploying-to-kubernetes#configuration-options) and [Quarkus OpenShift Extension configuration options](https://quarkus.io/guides/deploying-to-openshift#configuration-reference)). The [`do_build` function in the `generate-k8s-resources.sh` script](../scripts/generate-k8s-resources.sh) uses these extensions to generate the manifests in the [`deploy/k8s` directory](deploy/k8s).
+> **NOTE:** For non-OpenShift or minikube Kubernetes variants, you will most likely need to [push the image to a container registry](https://quarkus.io/guides/container-image#pushing) by adding the `-Dquarkus.container-image.push=true` flag, as well as setting the `quarkus.container-image.registry`, `quarkus.container-image.group`, and/or the `quarkus.container-image.name` properties to different values.
+
+| Target Platform        | Java Version | Command                                                                                                    |
+|------------------------|:------------:|------------------------------------------------------------------------------------------------------------|
+| Kubernetes             |      11      | `./mvnw clean package -Dquarkus.profile=kubernetes -Dquarkus.kubernetes.deploy=true -DskipTests`           |
+| Kubernetes             |      17      | `./mvnw clean package -Dquarkus.profile=kubernetes-17 -Dquarkus.kubernetes.deploy=true -DskipTests`        |
+| OpenShift              |      11      | `./mvnw clean package -Dquarkus.profile=openshift -Dquarkus.kubernetes.deploy=true -DskipTests`            |
+| OpenShift              |      17      | `./mvnw clean package -Dquarkus.profile=openshift-17 -Dquarkus.kubernetes.deploy=true -DskipTests`         |
+| Minikube               |      11      | `./mvnw clean package -Dquarkus.profile=minikube -Dquarkus.kubernetes.deploy=true -DskipTests`             |
+| Minikube               |      17      | `./mvnw clean package -Dquarkus.profile=minikube-17 -Dquarkus.kubernetes.deploy=true -DskipTests`          |
+| KNative                |      11      | `./mvnw clean package -Dquarkus.profile=knative -Dquarkus.kubernetes.deploy=true -DskipTests`              |
+| KNative                |      17      | `./mvnw clean package -Dquarkus.profile=knative-17 -Dquarkus.kubernetes.deploy=true -DskipTests`           |
+| KNative (on OpenShift) |      11      | `./mvnw clean package -Dquarkus.profile=knative-openshift -Dquarkus.kubernetes.deploy=true -DskipTests`    |
+| KNative (on OpenShift) |      17      | `./mvnw clean package -Dquarkus.profile=knative-openshift-17 -Dquarkus.kubernetes.deploy=true -DskipTests` |
+
+You may need to adjust other configuration options as well (see [Quarkus Kubernetes Extension configuration options](https://quarkus.io/guides/deploying-to-kubernetes#configuration-options) and [Quarkus OpenShift Extension configuration options](https://quarkus.io/guides/deploying-to-openshift#configuration-reference)).
+
+> The [`do_build` function in the `generate-k8s-resources.sh` script](../scripts/generate-k8s-resources.sh) uses these extensions to generate the manifests in the [`deploy/k8s` directory](deploy/k8s).

--- a/rest-fights/src/main/resources/application.properties
+++ b/rest-fights/src/main/resources/application.properties
@@ -68,8 +68,13 @@ quarkus.container-image.builder=docker
 quarkus.container-image.registry=quay.io
 quarkus.container-image.group=quarkus-super-heroes
 quarkus.container-image.name=${quarkus.application.name}
+paths.dockerfile.jvm-17=src/main/docker/Dockerfile.jvm17
+paths.base-image.jvm-17=registry.access.redhat.com/ubi8/openjdk-17:1.11
 
 # Kubernetes
+%kubernetes.quarkus.config.profile.parent=prod
+%kubernetes-17.quarkus.config.profile.parent=prod
+%kubernetes-17.quarkus.docker.dockerfile-jvm-path=${paths.dockerfile.jvm-17}
 quarkus.kubernetes.part-of=fights-service
 quarkus.kubernetes.env.configmaps=${quarkus.application.name}-config
 quarkus.kubernetes.env.secrets=${quarkus.application.name}-config-creds
@@ -79,6 +84,15 @@ quarkus.kubernetes.labels.application=${quarkus.kubernetes.part-of}
 quarkus.kubernetes.labels.system=quarkus-super-heroes
 
 # OpenShift
+%openshift.quarkus.config.profile.parent=prod
+%openshift.quarkus.kubernetes.deployment-target=openshift
+%openshift.quarkus.container-image.builder=openshift
+%openshift-17.quarkus.config.profile.parent=prod
+%openshift-17.quarkus.kubernetes.deployment-target=openshift
+%openshift-17.quarkus.container-image.builder=openshift
+%openshift-17.quarkus.docker.dockerfile-jvm-path=${paths.dockerfile.jvm-17}
+%openshift-17.quarkus.openshift.jvm-dockerfile=${paths.dockerfile.jvm-17}
+%openshift-17.quarkus.openshift.base-jvm-image=${paths.base-image.jvm-17}
 quarkus.openshift.part-of=${quarkus.kubernetes.part-of}
 quarkus.openshift.route.expose=true
 quarkus.openshift.annotations."app.openshift.io/connects-to"=fights-db,fights-kafka,apicurio,rest-villains,rest-heroes
@@ -89,6 +103,11 @@ quarkus.openshift.labels.application=${quarkus.kubernetes.labels.application}
 quarkus.openshift.labels.system=${quarkus.kubernetes.labels.system}
 
 # KNative
+%knative.quarkus.config.profile.parent=prod
+%knative.quarkus.kubernetes.deployment-target=knative
+%knative-17.quarkus.config.profile.parent=prod
+%knative-17.quarkus.kubernetes.deployment-target=knative
+%knative-17.quarkus.docker.dockerfile-jvm-path=${paths.dockerfile.jvm-17}
 quarkus.knative.part-of=${quarkus.kubernetes.part-of}
 quarkus.knative.annotations."app.openshift.io/connects-to"=fights-db,fights-kafka,apicurio,rest-villains,rest-heroes
 quarkus.knative.env.configmaps=${quarkus.kubernetes.env.configmaps}
@@ -96,3 +115,21 @@ quarkus.knative.env.secrets=${quarkus.kubernetes.env.secrets}
 quarkus.knative.labels.app=${quarkus.kubernetes.labels.app}
 quarkus.knative.labels.application=${quarkus.kubernetes.labels.application}
 quarkus.knative.labels.system=${quarkus.kubernetes.labels.system}
+
+# KNative on OpenShift
+%knative-openshift.quarkus.config.profile.parent=prod
+%knative-openshift.quarkus.container-image.builder=openshift
+%knative-openshift.quarkus.kubernetes.deployment-target=knative
+%knative-openshift-17.quarkus.config.profile.parent=prod
+%knative-openshift-17.quarkus.container-image.builder=openshift
+%knative-openshift-17.quarkus.kubernetes.deployment-target=knative
+%knative-openshift-17.quarkus.docker.dockerfile-jvm-path=${paths.dockerfile.jvm-17}
+%knative-openshift-17.quarkus.openshift.jvm-dockerfile=${paths.dockerfile.jvm-17}
+%knative-openshift-17.quarkus.openshift.base-jvm-image=${paths.base-image.jvm-17}
+
+# Minikube
+%minikube.quarkus.config.profile.parent=prod
+%minikube.quarkus.kubernetes.deployment-target=minikube
+%minikube-17.quarkus.config.profile.parent=prod
+%minikube-17.quarkus.kubernetes.deployment-target=minikube
+%minikube-17.quarkus.docker.dockerfile-jvm-path=${paths.dockerfile.jvm-17}

--- a/rest-heroes/README.md
+++ b/rest-heroes/README.md
@@ -95,6 +95,23 @@ The application is exposed outside of the cluster on port `80`.
 These are only the descriptors for this application and the required database only. If you want to deploy the entire system, [follow these instructions](../README.md#deploying-to-kubernetes).
 
 ### Deploying directly via Kubernetes Extensions
-Following the [deployment section](https://quarkus.io/guides/deploying-to-kubernetes#deployment) of the [Quarkus Kubernetes Extension Guide](https://quarkus.io/guides/deploying-to-kubernetes) (or the [deployment section](https://quarkus.io/guides/deploying-to-openshift#build-and-deployment) of the [Quarkus OpenShift Extension Guide](https://quarkus.io/guides/deploying-to-openshift) if deploying to [OpenShift](https://openshift.com)), you can run `./mvnw clean package -Dquarkus.kubernetes.deploy=true` to deploy the application and any of its dependencies (see [Kubernetes (and variants) resource generation](../docs/automation.md#kubernetes-and-variants-resource-generation) of the [automation strategy document](../docs/automation.md)) to Kubernetes or OpenShift.
+Following the [deployment section](https://quarkus.io/guides/deploying-to-kubernetes#deployment) of the [Quarkus Kubernetes Extension Guide](https://quarkus.io/guides/deploying-to-kubernetes) (or the [deployment section](https://quarkus.io/guides/deploying-to-openshift#build-and-deployment) of the [Quarkus OpenShift Extension Guide](https://quarkus.io/guides/deploying-to-openshift) if deploying to [OpenShift](https://openshift.com)), you can run one of the following commands to deploy the application and any of its dependencies (see [Kubernetes (and variants) resource generation](../docs/automation.md#kubernetes-and-variants-resource-generation) of the [automation strategy document](../docs/automation.md)) to your preferred Kubernetes distribution.
 
-You may need to adjust some of the other configuration options as well (see [Quarkus Kubernetes Extension configuration options](https://quarkus.io/guides/deploying-to-kubernetes#configuration-options) and [Quarkus OpenShift Extension configuration options](https://quarkus.io/guides/deploying-to-openshift#configuration-reference)). The [`do_build` function in the `generate-k8s-resources.sh` script](../scripts/generate-k8s-resources.sh) uses these extensions to generate the manifests in the [`deploy/k8s` directory](deploy/k8s).
+> **NOTE:** For non-OpenShift or minikube Kubernetes variants, you will most likely need to [push the image to a container registry](https://quarkus.io/guides/container-image#pushing) by adding the `-Dquarkus.container-image.push=true` flag, as well as setting the `quarkus.container-image.registry`, `quarkus.container-image.group`, and/or the `quarkus.container-image.name` properties to different values.
+
+| Target Platform        | Java Version | Command                                                                                                    |
+|------------------------|:------------:|------------------------------------------------------------------------------------------------------------|
+| Kubernetes             |      11      | `./mvnw clean package -Dquarkus.profile=kubernetes -Dquarkus.kubernetes.deploy=true -DskipTests`           |
+| Kubernetes             |      17      | `./mvnw clean package -Dquarkus.profile=kubernetes-17 -Dquarkus.kubernetes.deploy=true -DskipTests`        |
+| OpenShift              |      11      | `./mvnw clean package -Dquarkus.profile=openshift -Dquarkus.kubernetes.deploy=true -DskipTests`            |
+| OpenShift              |      17      | `./mvnw clean package -Dquarkus.profile=openshift-17 -Dquarkus.kubernetes.deploy=true -DskipTests`         |
+| Minikube               |      11      | `./mvnw clean package -Dquarkus.profile=minikube -Dquarkus.kubernetes.deploy=true -DskipTests`             |
+| Minikube               |      17      | `./mvnw clean package -Dquarkus.profile=minikube-17 -Dquarkus.kubernetes.deploy=true -DskipTests`          |
+| KNative                |      11      | `./mvnw clean package -Dquarkus.profile=knative -Dquarkus.kubernetes.deploy=true -DskipTests`              |
+| KNative                |      17      | `./mvnw clean package -Dquarkus.profile=knative-17 -Dquarkus.kubernetes.deploy=true -DskipTests`           |
+| KNative (on OpenShift) |      11      | `./mvnw clean package -Dquarkus.profile=knative-openshift -Dquarkus.kubernetes.deploy=true -DskipTests`    |
+| KNative (on OpenShift) |      17      | `./mvnw clean package -Dquarkus.profile=knative-openshift-17 -Dquarkus.kubernetes.deploy=true -DskipTests` |
+
+You may need to adjust other configuration options as well (see [Quarkus Kubernetes Extension configuration options](https://quarkus.io/guides/deploying-to-kubernetes#configuration-options) and [Quarkus OpenShift Extension configuration options](https://quarkus.io/guides/deploying-to-openshift#configuration-reference)).
+
+> The [`do_build` function in the `generate-k8s-resources.sh` script](../scripts/generate-k8s-resources.sh) uses these extensions to generate the manifests in the [`deploy/k8s` directory](deploy/k8s).

--- a/rest-heroes/src/main/resources/application.yml
+++ b/rest-heroes/src/main/resources/application.yml
@@ -1,3 +1,9 @@
+paths:
+  base-image:
+    jvm-17: registry.access.redhat.com/ubi8/openjdk-17:1.11
+  dockerfile:
+    jvm-17: src/main/docker/Dockerfile.jvm17
+
 quarkus:
   application:
     name: rest-heroes
@@ -69,3 +75,103 @@ quarkus:
   quarkus:
     hibernate-orm:
       sql-load-script: import.sql
+
+"%kubernetes":
+  quarkus:
+    config:
+      profile:
+        parent: prod
+
+"%kubernetes-17":
+  quarkus:
+    config:
+      profile:
+        parent: prod
+    docker:
+      dockerfile-jvm-path: "${paths.dockerfile.jvm-17}"
+
+"%openshift":
+  quarkus:
+    config:
+      profile:
+        parent: prod
+    container-image:
+      builder: openshift
+    kubernetes:
+      deployment-target: openshift
+
+"%openshift-17":
+  quarkus:
+    config:
+      profile:
+        parent: prod
+    container-image:
+      builder: openshift
+    docker:
+      dockerfile-jvm-path: "${paths.dockerfile.jvm-17}"
+    kubernetes:
+      deployment-target: openshift
+    openshift:
+      jvm-dockerfile: "${paths.dockerfile.jvm-17}"
+      base-jvm-image: "${paths.base-image.jvm-17}"
+
+"%knative":
+  quarkus:
+    config:
+      profile:
+        parent: prod
+    kubernetes:
+      deployment-target: knative
+
+"%knative-17":
+  quarkus:
+    config:
+      profile:
+        parent: prod
+    docker:
+      dockerfile-jvm-path: "${paths.dockerfile.jvm-17}"
+    kubernetes:
+      deployment-target: knative
+
+"%knative-openshift":
+  quarkus:
+    config:
+      profile:
+        parent: prod
+    container-image:
+      builder: openshift
+    kubernetes:
+      deployment-target: knative
+
+"%knative-openshift-17":
+  quarkus:
+    config:
+      profile:
+        parent: prod
+    container-image:
+      builder: openshift
+    docker:
+      dockerfile-jvm-path: "${paths.dockerfile.jvm-17}"
+    kubernetes:
+      deployment-target: knative
+    openshift:
+      jvm-dockerfile: "${paths.dockerfile.jvm-17}"
+      base-jvm-image: "${paths.base-image.jvm-17}"
+
+"%minikube":
+  quarkus:
+    config:
+      profile:
+        parent: prod
+    kubernetes:
+      deployment-target: minikube
+
+"%minikube-17":
+  quarkus:
+    config:
+      profile:
+        parent: prod
+    docker:
+      dockerfile-jvm-path: "${paths.dockerfile.jvm-17}"
+    kubernetes:
+      deployment-target: minikube

--- a/rest-villains/README.md
+++ b/rest-villains/README.md
@@ -95,6 +95,23 @@ The application is exposed outside of the cluster on port `80`.
 These are only the descriptors for this application and the required database only. If you want to deploy the entire system, [follow these instructions](../README.md#deploying-to-kubernetes).
 
 ### Deploying directly via Kubernetes Extensions
-Following the [deployment section](https://quarkus.io/guides/deploying-to-kubernetes#deployment) of the [Quarkus Kubernetes Extension Guide](https://quarkus.io/guides/deploying-to-kubernetes) (or the [deployment section](https://quarkus.io/guides/deploying-to-openshift#build-and-deployment) of the [Quarkus OpenShift Extension Guide](https://quarkus.io/guides/deploying-to-openshift) if deploying to [OpenShift](https://openshift.com)), you can run `./mvnw clean package -Dquarkus.kubernetes.deploy=true` to deploy the application and any of its dependencies (see [Kubernetes (and variants) resource generation](../docs/automation.md#kubernetes-and-variants-resource-generation) of the [automation strategy document](../docs/automation.md)) to Kubernetes or OpenShift.
+Following the [deployment section](https://quarkus.io/guides/deploying-to-kubernetes#deployment) of the [Quarkus Kubernetes Extension Guide](https://quarkus.io/guides/deploying-to-kubernetes) (or the [deployment section](https://quarkus.io/guides/deploying-to-openshift#build-and-deployment) of the [Quarkus OpenShift Extension Guide](https://quarkus.io/guides/deploying-to-openshift) if deploying to [OpenShift](https://openshift.com)), you can run one of the following commands to deploy the application and any of its dependencies (see [Kubernetes (and variants) resource generation](../docs/automation.md#kubernetes-and-variants-resource-generation) of the [automation strategy document](../docs/automation.md)) to your preferred Kubernetes distribution.
 
-You may need to adjust some of the other configuration options as well (see [Quarkus Kubernetes Extension configuration options](https://quarkus.io/guides/deploying-to-kubernetes#configuration-options) and [Quarkus OpenShift Extension configuration options](https://quarkus.io/guides/deploying-to-openshift#configuration-reference)). The [`do_build` function in the `generate-k8s-resources.sh` script](../scripts/generate-k8s-resources.sh) uses these extensions to generate the manifests in the [`deploy/k8s` directory](deploy/k8s).
+> **NOTE:** For non-OpenShift or minikube Kubernetes variants, you will most likely need to [push the image to a container registry](https://quarkus.io/guides/container-image#pushing) by adding the `-Dquarkus.container-image.push=true` flag, as well as setting the `quarkus.container-image.registry`, `quarkus.container-image.group`, and/or the `quarkus.container-image.name` properties to different values.
+
+| Target Platform        | Java Version | Command                                                                                                    |
+|------------------------|:------------:|------------------------------------------------------------------------------------------------------------|
+| Kubernetes             |      11      | `./mvnw clean package -Dquarkus.profile=kubernetes -Dquarkus.kubernetes.deploy=true -DskipTests`           |
+| Kubernetes             |      17      | `./mvnw clean package -Dquarkus.profile=kubernetes-17 -Dquarkus.kubernetes.deploy=true -DskipTests`        |
+| OpenShift              |      11      | `./mvnw clean package -Dquarkus.profile=openshift -Dquarkus.kubernetes.deploy=true -DskipTests`            |
+| OpenShift              |      17      | `./mvnw clean package -Dquarkus.profile=openshift-17 -Dquarkus.kubernetes.deploy=true -DskipTests`         |
+| Minikube               |      11      | `./mvnw clean package -Dquarkus.profile=minikube -Dquarkus.kubernetes.deploy=true -DskipTests`             |
+| Minikube               |      17      | `./mvnw clean package -Dquarkus.profile=minikube-17 -Dquarkus.kubernetes.deploy=true -DskipTests`          |
+| KNative                |      11      | `./mvnw clean package -Dquarkus.profile=knative -Dquarkus.kubernetes.deploy=true -DskipTests`              |
+| KNative                |      17      | `./mvnw clean package -Dquarkus.profile=knative-17 -Dquarkus.kubernetes.deploy=true -DskipTests`           |
+| KNative (on OpenShift) |      11      | `./mvnw clean package -Dquarkus.profile=knative-openshift -Dquarkus.kubernetes.deploy=true -DskipTests`    |
+| KNative (on OpenShift) |      17      | `./mvnw clean package -Dquarkus.profile=knative-openshift-17 -Dquarkus.kubernetes.deploy=true -DskipTests` |
+
+You may need to adjust other configuration options as well (see [Quarkus Kubernetes Extension configuration options](https://quarkus.io/guides/deploying-to-kubernetes#configuration-options) and [Quarkus OpenShift Extension configuration options](https://quarkus.io/guides/deploying-to-openshift#configuration-reference)).
+
+> The [`do_build` function in the `generate-k8s-resources.sh` script](../scripts/generate-k8s-resources.sh) uses these extensions to generate the manifests in the [`deploy/k8s` directory](deploy/k8s).

--- a/rest-villains/src/main/resources/application.properties
+++ b/rest-villains/src/main/resources/application.properties
@@ -38,8 +38,13 @@ quarkus.container-image.builder=docker
 quarkus.container-image.registry=quay.io
 quarkus.container-image.group=quarkus-super-heroes
 quarkus.container-image.name=${quarkus.application.name}
+paths.dockerfile.jvm-17=src/main/docker/Dockerfile.jvm17
+paths.base-image.jvm-17=registry.access.redhat.com/ubi8/openjdk-17:1.11
 
 # Kubernetes
+%kubernetes.quarkus.config.profile.parent=prod
+%kubernetes-17.quarkus.config.profile.parent=prod
+%kubernetes-17.quarkus.docker.dockerfile-jvm-path=${paths.dockerfile.jvm-17}
 quarkus.kubernetes.part-of=villains-service
 quarkus.kubernetes.annotations."app.openshift.io/connects-to"=villains-db
 quarkus.kubernetes.env.configmaps=${quarkus.application.name}-config
@@ -49,6 +54,15 @@ quarkus.kubernetes.labels.application=${quarkus.kubernetes.part-of}
 quarkus.kubernetes.labels.system=quarkus-super-heroes
 
 # OpenShift
+%openshift.quarkus.config.profile.parent=prod
+%openshift.quarkus.kubernetes.deployment-target=openshift
+%openshift.quarkus.container-image.builder=openshift
+%openshift-17.quarkus.config.profile.parent=prod
+%openshift-17.quarkus.kubernetes.deployment-target=openshift
+%openshift-17.quarkus.container-image.builder=openshift
+%openshift-17.quarkus.docker.dockerfile-jvm-path=${paths.dockerfile.jvm-17}
+%openshift-17.quarkus.openshift.jvm-dockerfile=${paths.dockerfile.jvm-17}
+%openshift-17.quarkus.openshift.base-jvm-image=${paths.base-image.jvm-17}
 quarkus.openshift.part-of=${quarkus.kubernetes.part-of}
 quarkus.openshift.route.expose=true
 quarkus.openshift.annotations."app.openshift.io/connects-to"=villains-db
@@ -59,6 +73,11 @@ quarkus.openshift.labels.application=${quarkus.kubernetes.labels.application}
 quarkus.openshift.labels.system=${quarkus.kubernetes.labels.system}
 
 # KNative
+%knative.quarkus.config.profile.parent=prod
+%knative.quarkus.kubernetes.deployment-target=knative
+%knative-17.quarkus.config.profile.parent=prod
+%knative-17.quarkus.kubernetes.deployment-target=knative
+%knative-17.quarkus.docker.dockerfile-jvm-path=${paths.dockerfile.jvm-17}
 quarkus.knative.part-of=${quarkus.kubernetes.part-of}
 quarkus.knative.annotations."app.openshift.io/connects-to"=villains-db
 quarkus.knative.env.configmaps=${quarkus.kubernetes.env.configmaps}
@@ -66,3 +85,21 @@ quarkus.knative.env.secrets=${quarkus.kubernetes.env.secrets}
 quarkus.knative.labels.app=${quarkus.kubernetes.labels.app}
 quarkus.knative.labels.application=${quarkus.kubernetes.labels.application}
 quarkus.knative.labels.system=${quarkus.kubernetes.labels.system}
+
+# KNative on OpenShift
+%knative-openshift.quarkus.config.profile.parent=prod
+%knative-openshift.quarkus.container-image.builder=openshift
+%knative-openshift.quarkus.kubernetes.deployment-target=knative
+%knative-openshift-17.quarkus.config.profile.parent=prod
+%knative-openshift-17.quarkus.container-image.builder=openshift
+%knative-openshift-17.quarkus.kubernetes.deployment-target=knative
+%knative-openshift-17.quarkus.docker.dockerfile-jvm-path=${paths.dockerfile.jvm-17}
+%knative-openshift-17.quarkus.openshift.jvm-dockerfile=${paths.dockerfile.jvm-17}
+%knative-openshift-17.quarkus.openshift.base-jvm-image=${paths.base-image.jvm-17}
+
+# Minikube
+%minikube.quarkus.config.profile.parent=prod
+%minikube.quarkus.kubernetes.deployment-target=minikube
+%minikube-17.quarkus.config.profile.parent=prod
+%minikube-17.quarkus.kubernetes.deployment-target=minikube
+%minikube-17.quarkus.docker.dockerfile-jvm-path=${paths.dockerfile.jvm-17}


### PR DESCRIPTION
Adding multiple profiles to each app to pre-configure deployment options if wanting to push/deploy directly from a developer machine to kubernetes.