### PR TITLE
Cleanup app.openshift.io/runtime label workaround

### DIFF
--- a/event-statistics/src/main/resources/application.properties
+++ b/event-statistics/src/main/resources/application.properties
@@ -65,9 +65,6 @@ quarkus.openshift.labels.app=${quarkus.kubernetes.labels.app}
 quarkus.openshift.labels.application=${quarkus.kubernetes.labels.application}
 quarkus.openshift.labels.system=${quarkus.kubernetes.labels.system}
 
-# This is to fix https://github.com/quarkusio/quarkus/issues/26516 for now
-quarkus.openshift.labels."app.openshift.io/runtime"=quarkus
-
 # KNative
 %knative.quarkus.config.profile.parent=prod
 %knative.quarkus.kubernetes.deployment-target=knative

--- a/rest-fights/src/main/resources/application.properties
+++ b/rest-fights/src/main/resources/application.properties
@@ -106,9 +106,6 @@ quarkus.openshift.labels.app=${quarkus.kubernetes.labels.app}
 quarkus.openshift.labels.application=${quarkus.kubernetes.labels.application}
 quarkus.openshift.labels.system=${quarkus.kubernetes.labels.system}
 
-# This is to fix https://github.com/quarkusio/quarkus/issues/26516 for now
-quarkus.openshift.labels."app.openshift.io/runtime"=quarkus
-
 # KNative
 %knative.quarkus.config.profile.parent=prod
 %knative.quarkus.kubernetes.deployment-target=knative

--- a/rest-heroes/src/main/resources/application.yml
+++ b/rest-heroes/src/main/resources/application.yml
@@ -69,9 +69,6 @@ quarkus:
       app: "${quarkus.kubernetes.labels.app}"
       application: "${quarkus.openshift.part-of}"
       system: "${quarkus.kubernetes.labels.system}"
-
-      # This is to fix https://github.com/quarkusio/quarkus/issues/26516 for now
-      "app.openshift.io/runtime": quarkus
   knative:
     part-of: "${quarkus.kubernetes.part-of}"
     annotations:

--- a/rest-villains/src/main/resources/application.properties
+++ b/rest-villains/src/main/resources/application.properties
@@ -83,9 +83,6 @@ quarkus.openshift.labels.app=${quarkus.kubernetes.labels.app}
 quarkus.openshift.labels.application=${quarkus.kubernetes.labels.application}
 quarkus.openshift.labels.system=${quarkus.kubernetes.labels.system}
 
-# This is to fix https://github.com/quarkusio/quarkus/issues/26516 for now
-quarkus.openshift.labels."app.openshift.io/runtime"=quarkus
-
 # KNative
 %knative.quarkus.config.profile.parent=prod
 %knative.quarkus.kubernetes.deployment-target=knative


### PR DESCRIPTION
Cleanup `app.openshift.io/runtime` label workaround now that quarkusio/quarkus#26516 is included in 2.10.3.Final.

Fixes #108