### PR TITLE
add trailing slash to Dockerfile COPY

### DIFF
--- a/ui-super-heroes/Dockerfile
+++ b/ui-super-heroes/Dockerfile
@@ -2,13 +2,13 @@
 FROM registry.access.redhat.com/ubi8/nodejs-16:1 as builder
 
 # Add dependencies
-COPY --chown=1001:1001 package*.json $HOME
+COPY --chown=1001:1001 package*.json $HOME/
 
 # Install dependencies
 RUN npm install
 
 # Add application sources
-COPY --chown=1001:1001 . $HOME
+COPY --chown=1001:1001 . $HOME/
 
 # Run build
 RUN npm run build && \


### PR DESCRIPTION
Run `cd ui-super-heroes && docker build .` and the build fails with the following error. Adding `/`'s fixes it.

```
Sending build context to Docker daemon  658.9kB
Step 1/10 : FROM registry.access.redhat.com/ubi8/nodejs-16:1 as builder
 ---> 0ffebd6de0e2
Step 2/10 : COPY --chown=1001:1001 package*.json $HOME
When using COPY with more than one source file, the destination must be a directory and end with a /
```

Output of `docker version`:

```
Client: Docker Engine - Community
 Version:           20.10.18
 API version:       1.41
 Go version:        go1.18.6
 Git commit:        b40c2f6
 Built:             Thu Sep  8 23:12:30 2022
 OS/Arch:           linux/amd64
 Context:           default
 Experimental:      true

Server: Docker Engine - Community
 Engine:
  Version:          20.10.18
  API version:      1.41 (minimum version 1.12)
  Go version:       go1.18.6
  Git commit:       e42327a
  Built:            Thu Sep  8 23:10:10 2022
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.6.8
  GitCommit:        9cd3357b7fd7218e4aec3eae239db1f68a5a6ec6
 runc:
  Version:          1.1.4
  GitCommit:        v1.1.4-0-g5fd4c4d
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```