### PR TITLE
Delete message from context before calling ack

### DIFF
--- a/event-statistics/src/main/java/io/quarkus/sample/superheroes/statistics/listener/SuperStats.java
+++ b/event-statistics/src/main/java/io/quarkus/sample/superheroes/statistics/listener/SuperStats.java
@@ -140,8 +140,11 @@ public class SuperStats {
   }
 
   private static Uni<Void> ackMessage(Context ctx) {
-    return Uni.createFrom().completionStage(ctx.<Message<Fight>>get(MESSAGE_KEY).ack())
-      .invoke(() -> ctx.delete(MESSAGE_KEY));
+    return Uni.createFrom().completionStage(() -> {
+        Message<Fight> message = ctx.get(MESSAGE_KEY);
+        ctx.delete(MESSAGE_KEY);
+        return message.ack();
+      });
   }
 
   private static void closeSpanFromContext(Context ctx, String spanName) {


### PR DESCRIPTION
When `ctx.delete` is called after ack, it can (and will) be executed after the arrival of another message, which itself overrides the previous message stored in the mutiny context.
Then when `ctx.delete` is executed, it removes the next message from the mutiny context, therefore no message is found when it is time to ack the second message.

The failure is triggered by a change in Reactive Messaging which executes message acks on duplicated message context. It results in better serialization of message consumption and message (n)acks.