### PR TITLE
Hero/Villain database pods failing

### DIFF
--- a/rest-heroes/src/main/kubernetes/knative.yml
+++ b/rest-heroes/src/main/kubernetes/knative.yml
@@ -77,7 +77,7 @@ spec:
         system: quarkus-super-heroes
     spec:
       containers:
-        - image: bitnami/postgresql:14
+        - image: bitnami/postgresql:14.4.0
           name: heroes-db
           ports:
             - containerPort: 5432

--- a/rest-heroes/src/main/kubernetes/kubernetes.yml
+++ b/rest-heroes/src/main/kubernetes/kubernetes.yml
@@ -77,7 +77,7 @@ spec:
         system: quarkus-super-heroes
     spec:
       containers:
-        - image: bitnami/postgresql:14
+        - image: bitnami/postgresql:14.4.0
           name: heroes-db
           ports:
             - containerPort: 5432

--- a/rest-heroes/src/main/kubernetes/minikube.yml
+++ b/rest-heroes/src/main/kubernetes/minikube.yml
@@ -77,7 +77,7 @@ spec:
         system: quarkus-super-heroes
     spec:
       containers:
-        - image: bitnami/postgresql:14
+        - image: bitnami/postgresql:14.4.0
           name: heroes-db
           ports:
             - containerPort: 5432

--- a/rest-heroes/src/main/kubernetes/openshift.yml
+++ b/rest-heroes/src/main/kubernetes/openshift.yml
@@ -77,7 +77,7 @@ spec:
         system: quarkus-super-heroes
     spec:
       containers:
-        - image: bitnami/postgresql:14
+        - image: bitnami/postgresql:14.4.0
           name: heroes-db
           ports:
             - containerPort: 5432

--- a/rest-villains/src/main/kubernetes/knative.yml
+++ b/rest-villains/src/main/kubernetes/knative.yml
@@ -76,7 +76,7 @@ spec:
         name: villains-db
     spec:
       containers:
-        - image: bitnami/postgresql:14
+        - image: bitnami/postgresql:14.4.0
           name: villains-db
           ports:
             - containerPort: 5432

--- a/rest-villains/src/main/kubernetes/kubernetes.yml
+++ b/rest-villains/src/main/kubernetes/kubernetes.yml
@@ -76,7 +76,7 @@ spec:
         name: villains-db
     spec:
       containers:
-        - image: bitnami/postgresql:14
+        - image: bitnami/postgresql:14.4.0
           name: villains-db
           ports:
             - containerPort: 5432

--- a/rest-villains/src/main/kubernetes/minikube.yml
+++ b/rest-villains/src/main/kubernetes/minikube.yml
@@ -76,7 +76,7 @@ spec:
         name: villains-db
     spec:
       containers:
-        - image: bitnami/postgresql:14
+        - image: bitnami/postgresql:14.4.0
           name: villains-db
           ports:
             - containerPort: 5432

--- a/rest-villains/src/main/kubernetes/openshift.yml
+++ b/rest-villains/src/main/kubernetes/openshift.yml
@@ -76,7 +76,7 @@ spec:
         name: villains-db
     spec:
       containers:
-        - image: bitnami/postgresql:14
+        - image: bitnami/postgresql:14.4.0
           name: villains-db
           ports:
             - containerPort: 5432


### PR DESCRIPTION
This seems to be due to the latest `bitnami/postgresql:14.5.0` image removing `curl` from it.

Fixes #154