### PR TITLE
Use initcontainers for heroes/villains postgres initialization

### DIFF
--- a/rest-heroes/src/main/kubernetes/knative.yml
+++ b/rest-heroes/src/main/kubernetes/knative.yml
@@ -76,8 +76,20 @@ spec:
         application: heroes-service
         system: quarkus-super-heroes
     spec:
+      initContainers:
+        - name: get-data
+          image: registry.access.redhat.com/ubi8-minimal:8.6
+          workingDir: /docker-entrypoint-preinitdb.d
+          command:
+            - 'sh'
+            - 'get-data.sh'
+          volumeMounts:
+            - name: heroes-db-init
+              mountPath: /docker-entrypoint-preinitdb.d
+            - name: heroes-db-init-data
+              mountPath: /docker-entrypoint-initdb.d
       containers:
-        - image: bitnami/postgresql:14.4.0
+        - image: bitnami/postgresql:14
           name: heroes-db
           ports:
             - containerPort: 5432
@@ -87,8 +99,8 @@ spec:
           volumeMounts:
             - name: heroes-db-data
               mountPath: /bitnami/postgresql
-            - name: heroes-db-init
-              mountPath: /docker-entrypoint-preinitdb.d
+            - name: heroes-db-init-data
+              mountPath: /docker-entrypoint-initdb.d
           resources:
             limits:
               memory: 128Mi
@@ -96,6 +108,8 @@ spec:
               memory: 32Mi
       volumes:
         - name: heroes-db-data
+          emptyDir: {}
+        - name: heroes-db-init-data
           emptyDir: {}
         - name: heroes-db-init
           configMap:

--- a/rest-heroes/src/main/kubernetes/kubernetes.yml
+++ b/rest-heroes/src/main/kubernetes/kubernetes.yml
@@ -76,8 +76,20 @@ spec:
         application: heroes-service
         system: quarkus-super-heroes
     spec:
+      initContainers:
+        - name: get-data
+          image: registry.access.redhat.com/ubi8-minimal:8.6
+          workingDir: /docker-entrypoint-preinitdb.d
+          command:
+            - 'sh'
+            - 'get-data.sh'
+          volumeMounts:
+            - name: heroes-db-init
+              mountPath: /docker-entrypoint-preinitdb.d
+            - name: heroes-db-init-data
+              mountPath: /docker-entrypoint-initdb.d
       containers:
-        - image: bitnami/postgresql:14.4.0
+        - image: bitnami/postgresql:14
           name: heroes-db
           ports:
             - containerPort: 5432
@@ -87,8 +99,8 @@ spec:
           volumeMounts:
             - name: heroes-db-data
               mountPath: /bitnami/postgresql
-            - name: heroes-db-init
-              mountPath: /docker-entrypoint-preinitdb.d
+            - name: heroes-db-init-data
+              mountPath: /docker-entrypoint-initdb.d
           resources:
             limits:
               memory: 128Mi
@@ -96,6 +108,8 @@ spec:
               memory: 32Mi
       volumes:
         - name: heroes-db-data
+          emptyDir: {}
+        - name: heroes-db-init-data
           emptyDir: {}
         - name: heroes-db-init
           configMap:

--- a/rest-heroes/src/main/kubernetes/minikube.yml
+++ b/rest-heroes/src/main/kubernetes/minikube.yml
@@ -76,8 +76,20 @@ spec:
         application: heroes-service
         system: quarkus-super-heroes
     spec:
+      initContainers:
+        - name: get-data
+          image: registry.access.redhat.com/ubi8-minimal:8.6
+          workingDir: /docker-entrypoint-preinitdb.d
+          command:
+            - 'sh'
+            - 'get-data.sh'
+          volumeMounts:
+            - name: heroes-db-init
+              mountPath: /docker-entrypoint-preinitdb.d
+            - name: heroes-db-init-data
+              mountPath: /docker-entrypoint-initdb.d
       containers:
-        - image: bitnami/postgresql:14.4.0
+        - image: bitnami/postgresql:14
           name: heroes-db
           ports:
             - containerPort: 5432
@@ -87,8 +99,8 @@ spec:
           volumeMounts:
             - name: heroes-db-data
               mountPath: /bitnami/postgresql
-            - name: heroes-db-init
-              mountPath: /docker-entrypoint-preinitdb.d
+            - name: heroes-db-init-data
+              mountPath: /docker-entrypoint-initdb.d
           resources:
             limits:
               memory: 128Mi
@@ -96,6 +108,8 @@ spec:
               memory: 32Mi
       volumes:
         - name: heroes-db-data
+          emptyDir: {}
+        - name: heroes-db-init-data
           emptyDir: {}
         - name: heroes-db-init
           configMap:

--- a/rest-heroes/src/main/kubernetes/openshift.yml
+++ b/rest-heroes/src/main/kubernetes/openshift.yml
@@ -76,8 +76,20 @@ spec:
         application: heroes-service
         system: quarkus-super-heroes
     spec:
+      initContainers:
+        - name: get-data
+          image: registry.access.redhat.com/ubi8-minimal:8.6
+          workingDir: /docker-entrypoint-preinitdb.d
+          command:
+            - 'sh'
+            - 'get-data.sh'
+          volumeMounts:
+            - name: heroes-db-init
+              mountPath: /docker-entrypoint-preinitdb.d
+            - name: heroes-db-init-data
+              mountPath: /docker-entrypoint-initdb.d
       containers:
-        - image: bitnami/postgresql:14.4.0
+        - image: bitnami/postgresql:14
           name: heroes-db
           ports:
             - containerPort: 5432
@@ -87,8 +99,8 @@ spec:
           volumeMounts:
             - name: heroes-db-data
               mountPath: /bitnami/postgresql
-            - name: heroes-db-init
-              mountPath: /docker-entrypoint-preinitdb.d
+            - name: heroes-db-init-data
+              mountPath: /docker-entrypoint-initdb.d
           resources:
             limits:
               memory: 128Mi
@@ -96,6 +108,8 @@ spec:
               memory: 32Mi
       volumes:
         - name: heroes-db-data
+          emptyDir: {}
+        - name: heroes-db-init-data
           emptyDir: {}
         - name: heroes-db-init
           configMap:

--- a/rest-villains/src/main/kubernetes/knative.yml
+++ b/rest-villains/src/main/kubernetes/knative.yml
@@ -75,8 +75,20 @@ spec:
         application: villains-service
         name: villains-db
     spec:
+      initContainers:
+        - name: get-data
+          image: registry.access.redhat.com/ubi8-minimal:8.6
+          workingDir: /docker-entrypoint-preinitdb.d
+          command:
+            - 'sh'
+            - 'get-data.sh'
+          volumeMounts:
+            - name: villains-db-init
+              mountPath: /docker-entrypoint-preinitdb.d
+            - name: villains-db-init-data
+              mountPath: /docker-entrypoint-initdb.d
       containers:
-        - image: bitnami/postgresql:14.4.0
+        - image: bitnami/postgresql:14
           name: villains-db
           ports:
             - containerPort: 5432
@@ -86,8 +98,8 @@ spec:
           volumeMounts:
             - name: villains-db-data
               mountPath: /bitnami/postgresql
-            - name: villains-db-init
-              mountPath: /docker-entrypoint-preinitdb.d
+            - name: villains-db-init-data
+              mountPath: /docker-entrypoint-initdb.d
           resources:
             limits:
               memory: 128Mi
@@ -95,6 +107,8 @@ spec:
               memory: 32Mi
       volumes:
         - name: villains-db-data
+          emptyDir: {}
+        - name: villains-db-init-data
           emptyDir: {}
         - name: villains-db-init
           configMap:

--- a/rest-villains/src/main/kubernetes/kubernetes.yml
+++ b/rest-villains/src/main/kubernetes/kubernetes.yml
@@ -75,8 +75,20 @@ spec:
         application: villains-service
         name: villains-db
     spec:
+      initContainers:
+        - name: get-data
+          image: registry.access.redhat.com/ubi8-minimal:8.6
+          workingDir: /docker-entrypoint-preinitdb.d
+          command:
+            - 'sh'
+            - 'get-data.sh'
+          volumeMounts:
+            - name: villains-db-init
+              mountPath: /docker-entrypoint-preinitdb.d
+            - name: villains-db-init-data
+              mountPath: /docker-entrypoint-initdb.d
       containers:
-        - image: bitnami/postgresql:14.4.0
+        - image: bitnami/postgresql:14
           name: villains-db
           ports:
             - containerPort: 5432
@@ -86,8 +98,8 @@ spec:
           volumeMounts:
             - name: villains-db-data
               mountPath: /bitnami/postgresql
-            - name: villains-db-init
-              mountPath: /docker-entrypoint-preinitdb.d
+            - name: villains-db-init-data
+              mountPath: /docker-entrypoint-initdb.d
           resources:
             limits:
               memory: 128Mi
@@ -95,6 +107,8 @@ spec:
               memory: 32Mi
       volumes:
         - name: villains-db-data
+          emptyDir: {}
+        - name: villains-db-init-data
           emptyDir: {}
         - name: villains-db-init
           configMap:

--- a/rest-villains/src/main/kubernetes/minikube.yml
+++ b/rest-villains/src/main/kubernetes/minikube.yml
@@ -75,8 +75,20 @@ spec:
         application: villains-service
         name: villains-db
     spec:
+      initContainers:
+        - name: get-data
+          image: registry.access.redhat.com/ubi8-minimal:8.6
+          workingDir: /docker-entrypoint-preinitdb.d
+          command:
+            - 'sh'
+            - 'get-data.sh'
+          volumeMounts:
+            - name: villains-db-init
+              mountPath: /docker-entrypoint-preinitdb.d
+            - name: villains-db-init-data
+              mountPath: /docker-entrypoint-initdb.d
       containers:
-        - image: bitnami/postgresql:14.4.0
+        - image: bitnami/postgresql:14
           name: villains-db
           ports:
             - containerPort: 5432
@@ -86,8 +98,8 @@ spec:
           volumeMounts:
             - name: villains-db-data
               mountPath: /bitnami/postgresql
-            - name: villains-db-init
-              mountPath: /docker-entrypoint-preinitdb.d
+            - name: villains-db-init-data
+              mountPath: /docker-entrypoint-initdb.d
           resources:
             limits:
               memory: 128Mi
@@ -95,6 +107,8 @@ spec:
               memory: 32Mi
       volumes:
         - name: villains-db-data
+          emptyDir: {}
+        - name: villains-db-init-data
           emptyDir: {}
         - name: villains-db-init
           configMap:

--- a/rest-villains/src/main/kubernetes/openshift.yml
+++ b/rest-villains/src/main/kubernetes/openshift.yml
@@ -75,8 +75,20 @@ spec:
         application: villains-service
         name: villains-db
     spec:
+      initContainers:
+        - name: get-data
+          image: registry.access.redhat.com/ubi8-minimal:8.6
+          workingDir: /docker-entrypoint-preinitdb.d
+          command:
+            - 'sh'
+            - 'get-data.sh'
+          volumeMounts:
+            - name: villains-db-init
+              mountPath: /docker-entrypoint-preinitdb.d
+            - name: villains-db-init-data
+              mountPath: /docker-entrypoint-initdb.d
       containers:
-        - image: bitnami/postgresql:14.4.0
+        - image: bitnami/postgresql:14
           name: villains-db
           ports:
             - containerPort: 5432
@@ -86,8 +98,8 @@ spec:
           volumeMounts:
             - name: villains-db-data
               mountPath: /bitnami/postgresql
-            - name: villains-db-init
-              mountPath: /docker-entrypoint-preinitdb.d
+            - name: villains-db-init-data
+              mountPath: /docker-entrypoint-initdb.d
           resources:
             limits:
               memory: 128Mi
@@ -95,6 +107,8 @@ spec:
               memory: 32Mi
       volumes:
         - name: villains-db-data
+          emptyDir: {}
+        - name: villains-db-init-data
           emptyDir: {}
         - name: villains-db-init
           configMap:


### PR DESCRIPTION
Use init containers for Heroes & Villains services for initializing the data in kubernetes.

Fixes #156