### PR TITLE
Have a smaller Postgres instance

### DIFF
--- a/docs/deploying-to-azure-containerapps.md
+++ b/docs/deploying-to-azure-containerapps.md
@@ -216,7 +216,7 @@ az postgres flexible-server create \
   --public all \
   --sku-name "Standard_$POSTGRES_SKU" \
   --tier "$POSTGRES_TIER" \
-  --storage-size 2048 \
+  --storage-size 256 \
   --version "$POSTGRES_DB_VERSION"
 ```
 
@@ -231,7 +231,7 @@ az postgres flexible-server create \
   --public all \
   --sku-name "Standard_$POSTGRES_SKU" \
   --tier "$POSTGRES_TIER" \
-  --storage-size 2048 \
+  --storage-size 256 \
   --version "$POSTGRES_DB_VERSION"
 ```
 

--- a/scripts/deploy-to-azure-containerapps.sh
+++ b/scripts/deploy-to-azure-containerapps.sh
@@ -76,7 +76,7 @@ create_postgres_db() {
     --public all \
     --sku-name "Standard_$POSTGRES_SKU" \
     --tier "$POSTGRES_TIER" \
-    --storage-size 2048 \
+    --storage-size 256 \
     --version "$POSTGRES_DB_VERSION"
   echo
 


### PR DESCRIPTION
We don't need such a big database in Azure. A smaller one will do (and is way cheaper)