### PR TITLE
Adding helm charts

### DIFF
--- a/.github/workflows/create-deploy-resources.yml
+++ b/.github/workflows/create-deploy-resources.yml
@@ -52,6 +52,10 @@ jobs:
         shell: bash
         run: scripts/generate-k8s-resources.sh
 
+      - name: Create helm charts
+        shell: bash
+        run: scripts/generate-helm-charts.sh
+
       - name: Create docker-compose resources
         shell: bash
         run: scripts/generate-docker-compose-resources.sh

--- a/event-statistics/deploy/helm/knative/event-statistics-java11-latest-knative/Chart.yaml
+++ b/event-statistics/deploy/helm/knative/event-statistics-java11-latest-knative/Chart.yaml
@@ -1,0 +1,4 @@
+---
+name: event-statistics-java11-latest-knative
+version: 1.0.0
+apiVersion: v2

--- a/event-statistics/deploy/helm/knative/event-statistics-java11-latest-knative/templates/NOTES.txt
+++ b/event-statistics/deploy/helm/knative/event-statistics-java11-latest-knative/templates/NOTES.txt
@@ -1,0 +1,72 @@
+# Quarkus Helm Notes
+
+To access the Helm annotations or properties you just need to have the following dependency in your
+class path:
+
+    <dependency>
+        <groupId>io.quarkiverse.helm</groupId>
+        <artifactId>quarkus-helm</artifactId>
+        <version>{quarkus-helm-version}</version>
+    </dependency>
+
+Build the project using:
+
+    mvn clean package
+
+You can find the generated Helm artifacts under: `target/helm/kubernetes/<chart name>/` that should look like:
+- Chart.yaml
+- values.yaml
+- templates/*.yml the generated resources by Quarkus Helm
+
+**Note**: The `<chart name>` is set from either the property `quarkus.helm.name` or the `@HelmChart` annotation or the Quarkus application.
+
+# Requirements
+
+- Have installed [the Helm command line](https://helm.sh/docs/intro/install/)
+- Have connected/logged to a kubernetes cluster
+- Configure your Quarkus application to use any of the Quarkus Kubernetes extensions like Quarkus Kubernetes, Quarkus OpenShift or Quarkus Knative.
+- Configure your Quarkus application to use any of [the Quarkus Container Image extensions](https://quarkus.io/guides/container-image) - This example uses `container-image-docker`.
+
+# How can it be used?
+
+You can run the following Maven command in order to generate the Helm artifacts and build/push the image into a container registry:
+
+```shell
+mvn clean package -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=<your container registry> -Dquarkus.container-image.group=<your container registry namespace>
+```
+
+This command will push the image to a container registry and will become available when a pod or container is created.
+
+Finally, let's use Helm to deploy it into the cluster:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name>
+```
+
+The above command will deploy a chart using the default values (as defined within the `values.yaml` file). We can override the default values to use your `values.dev.yaml` file by executing the following command:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name> --values ./target/helm/<chart name>/kubernetes/values.dev.yaml
+```
+
+How can I update my deployment?
+
+- Via the `upgrade` option of Helm command line:
+
+After making changes to your project and regenerating the Helm resources and the application container image, then you need to upgrade your deployment:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name>
+```
+
+- Via the `set` option of Helm command line:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name> --set <app name>.replicas=1
+```
+
+How can we delete my deployment?
+
+```shell
+helm uninstall helm-example
+```

--- a/event-statistics/deploy/helm/knative/event-statistics-java11-latest-knative/templates/configmap.yaml
+++ b/event-statistics/deploy/helm/knative/event-statistics-java11-latest-knative/templates/configmap.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: event-statistics
+    application: event-stats
+    system: quarkus-super-heroes
+  name: event-statistics-config
+data:
+  kafka.bootstrap.servers: PLAINTEXT://fights-kafka:9092
+  mp.messaging.connector.smallrye-kafka.apicurio.registry.url: http://apicurio:8080/apis/registry/v2
+  quarkus.opentelemetry.tracer.exporter.otlp.endpoint: http://otel-collector:4317

--- a/event-statistics/deploy/helm/knative/event-statistics-java11-latest-knative/templates/deployment.yaml
+++ b/event-statistics/deploy/helm/knative/event-statistics-java11-latest-knative/templates/deployment.yaml
@@ -1,0 +1,112 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: fights-kafka
+    application: fights-service
+    app.kubernetes.io/part-of: fights-service
+    app.openshift.io/runtime: amq
+    system: quarkus-super-heroes
+  name: fights-kafka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: fights-kafka
+  template:
+    metadata:
+      labels:
+        application: fights-service
+        name: fights-kafka
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - command:
+            - sh
+            - -c
+            - "export CLUSTER_ID=$(bin/kafka-storage.sh random-uuid) && bin/kafka-storage.sh format -t ${CLUSTER_ID} -c config/kraft/server.properties && bin/kafka-server-start.sh config/kraft/server.properties --override advertised.listeners=${KAFKA_ADVERTISED_LISTENERS}"
+          env:
+            - name: LOG_DIR
+              value: /tmp/logs
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: PLAINTEXT://fights-kafka:9092
+          image: quay.io/strimzi/kafka:0.28.0-kafka-3.1.0
+          name: fights-kafka
+          ports:
+            - containerPort: 9092
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 128Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
+  labels:
+    app: apicurio
+    application: fights-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: fights-service
+    app.kubernetes.io/name: apicurio
+    app.kubernetes.io/version: 2.2.3.Final
+    app.openshift.io/runtime: apicurio
+  name: apicurio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: apicurio
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scheme: http
+      labels:
+        application: fights-service
+        name: apicurio
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - env:
+            - name: REGISTRY_AUTH_ANONYMOUS_READ_ACCESS_ENABLED
+              value: "true"
+          image: quay.io/apicurio/apicurio-registry-mem:2.2.3.Final
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health/live
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          name: apicurio
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health/ready
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 128Mi

--- a/event-statistics/deploy/helm/knative/event-statistics-java11-latest-knative/templates/secret.yaml
+++ b/event-statistics/deploy/helm/knative/event-statistics-java11-latest-knative/templates/secret.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: event-statistics
+    application: event-stats
+    system: quarkus-super-heroes
+  name: event-statistics-config-creds
+type: Opaque

--- a/event-statistics/deploy/helm/knative/event-statistics-java11-latest-knative/templates/service.yaml
+++ b/event-statistics/deploy/helm/knative/event-statistics-java11-latest-knative/templates/service.yaml
@@ -1,0 +1,103 @@
+---
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  annotations:
+    app.openshift.io/connects-to: "fights-kafka,apicurio,otel-collector"
+    app.openshift.io/vcs-ref: main
+    app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:52:21 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8085"
+    prometheus.io/scheme: http
+  labels:
+    app: event-statistics
+    app.openshift.io/runtime: quarkus
+    application: event-stats
+    system: quarkus-super-heroes
+    app.kubernetes.io/name: event-statistics
+    app.kubernetes.io/part-of: event-stats
+    app.kubernetes.io/version: java11-latest
+  name: event-statistics
+spec:
+  template:
+    spec:
+      containers:
+        - envFrom:
+            - configMapRef:
+                name: event-statistics-config
+            - secretRef:
+                name: event-statistics-config-creds
+          image: {{ .Values.app.image }}
+          imagePullPolicy: Always
+          livenessProbe:
+            failureThreshold: {{ .Values.app.livenessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.livenessProbe.httpGet.path }}
+              port: {{ .Values.app.livenessProbe.httpGet.port }}
+              scheme: {{ .Values.app.livenessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.livenessProbe.timeoutSeconds }}
+          name: event-statistics
+          ports:
+            - containerPort: 8085
+              name: http1
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: {{ .Values.app.readinessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.readinessProbe.httpGet.path }}
+              port: {{ .Values.app.readinessProbe.httpGet.port }}
+              scheme: {{ .Values.app.readinessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.readinessProbe.timeoutSeconds }}
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: fights-kafka
+    application: fights-service
+    system: quarkus-super-heroes
+  name: fights-kafka
+spec:
+  ports:
+    - port: 9092
+      protocol: TCP
+      targetPort: 9092
+  selector:
+    name: fights-kafka
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
+  labels:
+    name: apicurio
+    application: fights-service
+    system: quarkus-super-heroes
+  name: apicurio
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    name: apicurio
+  type: ClusterIP

--- a/event-statistics/deploy/helm/knative/event-statistics-java11-latest-knative/values.yaml
+++ b/event-statistics/deploy/helm/knative/event-statistics-java11-latest-knative/values.yaml
@@ -1,0 +1,24 @@
+---
+app:
+  serviceType: ClusterIP
+  livenessProbe:
+    failureThreshold: 3
+    periodSeconds: 10
+    timeoutSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/live
+      scheme: HTTP
+      port: ":START:{{ .Values.app.livenessProbe.httpGet.port }}:END:"
+  image: event-statistics:java11-latest
+  readinessProbe:
+    failureThreshold: 3
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/ready
+      scheme: HTTP
+      port: ":START:{{ .Values.app.readinessProbe.httpGet.port }}:END:"

--- a/event-statistics/deploy/helm/kubernetes/event-statistics-java11-latest-kubernetes/Chart.yaml
+++ b/event-statistics/deploy/helm/kubernetes/event-statistics-java11-latest-kubernetes/Chart.yaml
@@ -1,0 +1,4 @@
+---
+name: event-statistics-java11-latest-kubernetes
+version: 1.0.0
+apiVersion: v2

--- a/event-statistics/deploy/helm/kubernetes/event-statistics-java11-latest-kubernetes/templates/NOTES.txt
+++ b/event-statistics/deploy/helm/kubernetes/event-statistics-java11-latest-kubernetes/templates/NOTES.txt
@@ -1,0 +1,72 @@
+# Quarkus Helm Notes
+
+To access the Helm annotations or properties you just need to have the following dependency in your
+class path:
+
+    <dependency>
+        <groupId>io.quarkiverse.helm</groupId>
+        <artifactId>quarkus-helm</artifactId>
+        <version>{quarkus-helm-version}</version>
+    </dependency>
+
+Build the project using:
+
+    mvn clean package
+
+You can find the generated Helm artifacts under: `target/helm/kubernetes/<chart name>/` that should look like:
+- Chart.yaml
+- values.yaml
+- templates/*.yml the generated resources by Quarkus Helm
+
+**Note**: The `<chart name>` is set from either the property `quarkus.helm.name` or the `@HelmChart` annotation or the Quarkus application.
+
+# Requirements
+
+- Have installed [the Helm command line](https://helm.sh/docs/intro/install/)
+- Have connected/logged to a kubernetes cluster
+- Configure your Quarkus application to use any of the Quarkus Kubernetes extensions like Quarkus Kubernetes, Quarkus OpenShift or Quarkus Knative.
+- Configure your Quarkus application to use any of [the Quarkus Container Image extensions](https://quarkus.io/guides/container-image) - This example uses `container-image-docker`.
+
+# How can it be used?
+
+You can run the following Maven command in order to generate the Helm artifacts and build/push the image into a container registry:
+
+```shell
+mvn clean package -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=<your container registry> -Dquarkus.container-image.group=<your container registry namespace>
+```
+
+This command will push the image to a container registry and will become available when a pod or container is created.
+
+Finally, let's use Helm to deploy it into the cluster:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name>
+```
+
+The above command will deploy a chart using the default values (as defined within the `values.yaml` file). We can override the default values to use your `values.dev.yaml` file by executing the following command:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name> --values ./target/helm/<chart name>/kubernetes/values.dev.yaml
+```
+
+How can I update my deployment?
+
+- Via the `upgrade` option of Helm command line:
+
+After making changes to your project and regenerating the Helm resources and the application container image, then you need to upgrade your deployment:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name>
+```
+
+- Via the `set` option of Helm command line:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name> --set <app name>.replicas=1
+```
+
+How can we delete my deployment?
+
+```shell
+helm uninstall helm-example
+```

--- a/event-statistics/deploy/helm/kubernetes/event-statistics-java11-latest-kubernetes/templates/configmap.yaml
+++ b/event-statistics/deploy/helm/kubernetes/event-statistics-java11-latest-kubernetes/templates/configmap.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: event-statistics
+    application: event-stats
+    system: quarkus-super-heroes
+  name: event-statistics-config
+data:
+  kafka.bootstrap.servers: PLAINTEXT://fights-kafka:9092
+  mp.messaging.connector.smallrye-kafka.apicurio.registry.url: http://apicurio:8080/apis/registry/v2
+  quarkus.opentelemetry.tracer.exporter.otlp.endpoint: http://otel-collector:4317

--- a/event-statistics/deploy/helm/kubernetes/event-statistics-java11-latest-kubernetes/templates/deployment.yaml
+++ b/event-statistics/deploy/helm/kubernetes/event-statistics-java11-latest-kubernetes/templates/deployment.yaml
@@ -1,0 +1,204 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    app.openshift.io/connects-to: "fights-kafka,apicurio,otel-collector"
+    app.quarkus.io/vcs-ref: main
+    app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:45:12 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8085"
+    prometheus.io/scheme: http
+  labels:
+    app: event-statistics
+    application: event-stats
+    system: quarkus-super-heroes
+    app.kubernetes.io/name: event-statistics
+    app.kubernetes.io/part-of: event-stats
+    app.kubernetes.io/version: java11-latest
+  name: event-statistics
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: event-statistics
+      app.kubernetes.io/part-of: event-stats
+      app.kubernetes.io/version: java11-latest
+  template:
+    metadata:
+      annotations:
+        app.openshift.io/connects-to: "fights-kafka,apicurio,otel-collector"
+        app.quarkus.io/vcs-ref: main
+        app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+        app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+        app.quarkus.io/build-timestamp: 2023-02-20 - 20:45:12 +0000
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /q/metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scheme: http
+      labels:
+        app: event-statistics
+        application: event-stats
+        system: quarkus-super-heroes
+        app.kubernetes.io/name: event-statistics
+        app.kubernetes.io/part-of: event-stats
+        app.kubernetes.io/version: java11-latest
+    spec:
+      containers:
+        - env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom:
+            - configMapRef:
+                name: event-statistics-config
+            - secretRef:
+                name: event-statistics-config-creds
+          image: {{ .Values.app.image }}
+          imagePullPolicy: Always
+          livenessProbe:
+            failureThreshold: {{ .Values.app.livenessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.livenessProbe.httpGet.path }}
+              port: {{ .Values.app.livenessProbe.httpGet.port }}
+              scheme: {{ .Values.app.livenessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.livenessProbe.timeoutSeconds }}
+          name: event-statistics
+          ports:
+            - containerPort: 8085
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: {{ .Values.app.readinessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.readinessProbe.httpGet.path }}
+              port: {{ .Values.app.readinessProbe.httpGet.port }}
+              scheme: {{ .Values.app.readinessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.readinessProbe.timeoutSeconds }}
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 256Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: fights-kafka
+    application: fights-service
+    app.kubernetes.io/part-of: fights-service
+    app.openshift.io/runtime: amq
+    system: quarkus-super-heroes
+  name: fights-kafka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: fights-kafka
+  template:
+    metadata:
+      labels:
+        application: fights-service
+        name: fights-kafka
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - command:
+            - sh
+            - -c
+            - "export CLUSTER_ID=$(bin/kafka-storage.sh random-uuid) && bin/kafka-storage.sh format -t ${CLUSTER_ID} -c config/kraft/server.properties && bin/kafka-server-start.sh config/kraft/server.properties --override advertised.listeners=${KAFKA_ADVERTISED_LISTENERS}"
+          env:
+            - name: LOG_DIR
+              value: /tmp/logs
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: PLAINTEXT://fights-kafka:9092
+          image: quay.io/strimzi/kafka:0.28.0-kafka-3.1.0
+          name: fights-kafka
+          ports:
+            - containerPort: 9092
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 128Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
+  labels:
+    app: apicurio
+    application: fights-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: fights-service
+    app.kubernetes.io/name: apicurio
+    app.kubernetes.io/version: 2.2.3.Final
+    app.openshift.io/runtime: apicurio
+  name: apicurio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: apicurio
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scheme: http
+      labels:
+        application: fights-service
+        name: apicurio
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - env:
+            - name: REGISTRY_AUTH_ANONYMOUS_READ_ACCESS_ENABLED
+              value: "true"
+          image: quay.io/apicurio/apicurio-registry-mem:2.2.3.Final
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health/live
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          name: apicurio
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health/ready
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 128Mi

--- a/event-statistics/deploy/helm/kubernetes/event-statistics-java11-latest-kubernetes/templates/secret.yaml
+++ b/event-statistics/deploy/helm/kubernetes/event-statistics-java11-latest-kubernetes/templates/secret.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: event-statistics
+    application: event-stats
+    system: quarkus-super-heroes
+  name: event-statistics-config-creds
+type: Opaque

--- a/event-statistics/deploy/helm/kubernetes/event-statistics-java11-latest-kubernetes/templates/service.yaml
+++ b/event-statistics/deploy/helm/kubernetes/event-statistics-java11-latest-kubernetes/templates/service.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: fights-kafka
+    application: fights-service
+    system: quarkus-super-heroes
+  name: fights-kafka
+spec:
+  ports:
+    - port: 9092
+      protocol: TCP
+      targetPort: 9092
+  selector:
+    name: fights-kafka
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
+  labels:
+    name: apicurio
+    application: fights-service
+    system: quarkus-super-heroes
+  name: apicurio
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    name: apicurio
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    app.openshift.io/connects-to: "fights-kafka,apicurio,otel-collector"
+    app.quarkus.io/vcs-ref: main
+    app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:45:12 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8085"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: event-statistics
+    app.kubernetes.io/part-of: event-stats
+    app.kubernetes.io/version: java11-latest
+    app: event-statistics
+    application: event-stats
+    system: quarkus-super-heroes
+  name: event-statistics
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8085
+  selector:
+    app.kubernetes.io/name: event-statistics
+    app.kubernetes.io/part-of: event-stats
+    app.kubernetes.io/version: java11-latest
+  type: {{ .Values.app.serviceType }}

--- a/event-statistics/deploy/helm/kubernetes/event-statistics-java11-latest-kubernetes/values.yaml
+++ b/event-statistics/deploy/helm/kubernetes/event-statistics-java11-latest-kubernetes/values.yaml
@@ -1,0 +1,24 @@
+---
+app:
+  serviceType: ClusterIP
+  livenessProbe:
+    failureThreshold: 3
+    periodSeconds: 10
+    timeoutSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/live
+      scheme: HTTP
+      port: 8085
+  image: quay.io/quarkus-super-heroes/event-statistics:java11-latest
+  readinessProbe:
+    failureThreshold: 3
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/ready
+      scheme: HTTP
+      port: 8085

--- a/event-statistics/deploy/helm/minikube/event-statistics-java11-latest-minikube/Chart.yaml
+++ b/event-statistics/deploy/helm/minikube/event-statistics-java11-latest-minikube/Chart.yaml
@@ -1,0 +1,4 @@
+---
+name: event-statistics-java11-latest-minikube
+version: 1.0.0
+apiVersion: v2

--- a/event-statistics/deploy/helm/minikube/event-statistics-java11-latest-minikube/templates/NOTES.txt
+++ b/event-statistics/deploy/helm/minikube/event-statistics-java11-latest-minikube/templates/NOTES.txt
@@ -1,0 +1,72 @@
+# Quarkus Helm Notes
+
+To access the Helm annotations or properties you just need to have the following dependency in your
+class path:
+
+    <dependency>
+        <groupId>io.quarkiverse.helm</groupId>
+        <artifactId>quarkus-helm</artifactId>
+        <version>{quarkus-helm-version}</version>
+    </dependency>
+
+Build the project using:
+
+    mvn clean package
+
+You can find the generated Helm artifacts under: `target/helm/kubernetes/<chart name>/` that should look like:
+- Chart.yaml
+- values.yaml
+- templates/*.yml the generated resources by Quarkus Helm
+
+**Note**: The `<chart name>` is set from either the property `quarkus.helm.name` or the `@HelmChart` annotation or the Quarkus application.
+
+# Requirements
+
+- Have installed [the Helm command line](https://helm.sh/docs/intro/install/)
+- Have connected/logged to a kubernetes cluster
+- Configure your Quarkus application to use any of the Quarkus Kubernetes extensions like Quarkus Kubernetes, Quarkus OpenShift or Quarkus Knative.
+- Configure your Quarkus application to use any of [the Quarkus Container Image extensions](https://quarkus.io/guides/container-image) - This example uses `container-image-docker`.
+
+# How can it be used?
+
+You can run the following Maven command in order to generate the Helm artifacts and build/push the image into a container registry:
+
+```shell
+mvn clean package -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=<your container registry> -Dquarkus.container-image.group=<your container registry namespace>
+```
+
+This command will push the image to a container registry and will become available when a pod or container is created.
+
+Finally, let's use Helm to deploy it into the cluster:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name>
+```
+
+The above command will deploy a chart using the default values (as defined within the `values.yaml` file). We can override the default values to use your `values.dev.yaml` file by executing the following command:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name> --values ./target/helm/<chart name>/kubernetes/values.dev.yaml
+```
+
+How can I update my deployment?
+
+- Via the `upgrade` option of Helm command line:
+
+After making changes to your project and regenerating the Helm resources and the application container image, then you need to upgrade your deployment:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name>
+```
+
+- Via the `set` option of Helm command line:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name> --set <app name>.replicas=1
+```
+
+How can we delete my deployment?
+
+```shell
+helm uninstall helm-example
+```

--- a/event-statistics/deploy/helm/minikube/event-statistics-java11-latest-minikube/templates/configmap.yaml
+++ b/event-statistics/deploy/helm/minikube/event-statistics-java11-latest-minikube/templates/configmap.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: event-statistics
+    application: event-stats
+    system: quarkus-super-heroes
+  name: event-statistics-config
+data:
+  kafka.bootstrap.servers: PLAINTEXT://fights-kafka:9092
+  mp.messaging.connector.smallrye-kafka.apicurio.registry.url: http://apicurio:8080/apis/registry/v2
+  quarkus.opentelemetry.tracer.exporter.otlp.endpoint: http://otel-collector:4317

--- a/event-statistics/deploy/helm/minikube/event-statistics-java11-latest-minikube/templates/deployment.yaml
+++ b/event-statistics/deploy/helm/minikube/event-statistics-java11-latest-minikube/templates/deployment.yaml
@@ -1,0 +1,204 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    app.quarkus.io/vcs-ref: main
+    app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "fights-kafka,apicurio,otel-collector"
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:47:39 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8085"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: event-statistics
+    app.kubernetes.io/part-of: event-stats
+    app.kubernetes.io/version: java11-latest
+    app: event-statistics
+    application: event-stats
+    system: quarkus-super-heroes
+  name: event-statistics
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: event-statistics
+      app.kubernetes.io/part-of: event-stats
+      app.kubernetes.io/version: java11-latest
+  template:
+    metadata:
+      annotations:
+        app.quarkus.io/vcs-ref: main
+        app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+        app.openshift.io/connects-to: "fights-kafka,apicurio,otel-collector"
+        app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+        app.quarkus.io/build-timestamp: 2023-02-20 - 20:47:39 +0000
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /q/metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scheme: http
+      labels:
+        app.kubernetes.io/name: event-statistics
+        app.kubernetes.io/part-of: event-stats
+        app.kubernetes.io/version: java11-latest
+        app: event-statistics
+        application: event-stats
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom:
+            - configMapRef:
+                name: event-statistics-config
+            - secretRef:
+                name: event-statistics-config-creds
+          image: {{ .Values.app.image }}
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: {{ .Values.app.livenessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.livenessProbe.httpGet.path }}
+              port: {{ .Values.app.livenessProbe.httpGet.port }}
+              scheme: {{ .Values.app.livenessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.livenessProbe.timeoutSeconds }}
+          name: event-statistics
+          ports:
+            - containerPort: 8085
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: {{ .Values.app.readinessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.readinessProbe.httpGet.path }}
+              port: {{ .Values.app.readinessProbe.httpGet.port }}
+              scheme: {{ .Values.app.readinessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.readinessProbe.timeoutSeconds }}
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 256Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: fights-kafka
+    application: fights-service
+    app.kubernetes.io/part-of: fights-service
+    app.openshift.io/runtime: amq
+    system: quarkus-super-heroes
+  name: fights-kafka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: fights-kafka
+  template:
+    metadata:
+      labels:
+        application: fights-service
+        name: fights-kafka
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - command:
+            - sh
+            - -c
+            - "export CLUSTER_ID=$(bin/kafka-storage.sh random-uuid) && bin/kafka-storage.sh format -t ${CLUSTER_ID} -c config/kraft/server.properties && bin/kafka-server-start.sh config/kraft/server.properties --override advertised.listeners=${KAFKA_ADVERTISED_LISTENERS}"
+          env:
+            - name: LOG_DIR
+              value: /tmp/logs
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: PLAINTEXT://fights-kafka:9092
+          image: quay.io/strimzi/kafka:0.28.0-kafka-3.1.0
+          name: fights-kafka
+          ports:
+            - containerPort: 9092
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 128Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
+  labels:
+    app: apicurio
+    application: fights-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: fights-service
+    app.kubernetes.io/name: apicurio
+    app.kubernetes.io/version: 2.2.3.Final
+    app.openshift.io/runtime: apicurio
+  name: apicurio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: apicurio
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scheme: http
+      labels:
+        application: fights-service
+        name: apicurio
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - env:
+            - name: REGISTRY_AUTH_ANONYMOUS_READ_ACCESS_ENABLED
+              value: "true"
+          image: quay.io/apicurio/apicurio-registry-mem:2.2.3.Final
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health/live
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          name: apicurio
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health/ready
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 128Mi

--- a/event-statistics/deploy/helm/minikube/event-statistics-java11-latest-minikube/templates/secret.yaml
+++ b/event-statistics/deploy/helm/minikube/event-statistics-java11-latest-minikube/templates/secret.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: event-statistics
+    application: event-stats
+    system: quarkus-super-heroes
+  name: event-statistics-config-creds
+type: Opaque

--- a/event-statistics/deploy/helm/minikube/event-statistics-java11-latest-minikube/templates/service.yaml
+++ b/event-statistics/deploy/helm/minikube/event-statistics-java11-latest-minikube/templates/service.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: fights-kafka
+    application: fights-service
+    system: quarkus-super-heroes
+  name: fights-kafka
+spec:
+  ports:
+    - port: 9092
+      protocol: TCP
+      targetPort: 9092
+  selector:
+    name: fights-kafka
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
+  labels:
+    name: apicurio
+    application: fights-service
+    system: quarkus-super-heroes
+  name: apicurio
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    name: apicurio
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    app.quarkus.io/vcs-ref: main
+    app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "fights-kafka,apicurio,otel-collector"
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:47:39 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8085"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: event-statistics
+    app.kubernetes.io/part-of: event-stats
+    app.kubernetes.io/version: java11-latest
+    app: event-statistics
+    application: event-stats
+    system: quarkus-super-heroes
+  name: event-statistics
+spec:
+  ports:
+    - name: http
+      nodePort: 30938
+      port: 80
+      protocol: TCP
+      targetPort: 8085
+  selector:
+    app.kubernetes.io/name: event-statistics
+    app.kubernetes.io/part-of: event-stats
+    app.kubernetes.io/version: java11-latest
+  type: {{ .Values.app.serviceType }}

--- a/event-statistics/deploy/helm/minikube/event-statistics-java11-latest-minikube/values.yaml
+++ b/event-statistics/deploy/helm/minikube/event-statistics-java11-latest-minikube/values.yaml
@@ -1,0 +1,24 @@
+---
+app:
+  serviceType: ClusterIP
+  livenessProbe:
+    failureThreshold: 3
+    periodSeconds: 10
+    timeoutSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/live
+      scheme: HTTP
+      port: 8085
+  image: event-statistics:java11-latest
+  readinessProbe:
+    failureThreshold: 3
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/ready
+      scheme: HTTP
+      port: 8085

--- a/event-statistics/deploy/helm/openshift/event-statistics-java11-latest-openshift/Chart.yaml
+++ b/event-statistics/deploy/helm/openshift/event-statistics-java11-latest-openshift/Chart.yaml
@@ -1,0 +1,4 @@
+---
+name: event-statistics-java11-latest-openshift
+version: 1.0.0
+apiVersion: v2

--- a/event-statistics/deploy/helm/openshift/event-statistics-java11-latest-openshift/templates/NOTES.txt
+++ b/event-statistics/deploy/helm/openshift/event-statistics-java11-latest-openshift/templates/NOTES.txt
@@ -1,0 +1,72 @@
+# Quarkus Helm Notes
+
+To access the Helm annotations or properties you just need to have the following dependency in your
+class path:
+
+    <dependency>
+        <groupId>io.quarkiverse.helm</groupId>
+        <artifactId>quarkus-helm</artifactId>
+        <version>{quarkus-helm-version}</version>
+    </dependency>
+
+Build the project using:
+
+    mvn clean package
+
+You can find the generated Helm artifacts under: `target/helm/kubernetes/<chart name>/` that should look like:
+- Chart.yaml
+- values.yaml
+- templates/*.yml the generated resources by Quarkus Helm
+
+**Note**: The `<chart name>` is set from either the property `quarkus.helm.name` or the `@HelmChart` annotation or the Quarkus application.
+
+# Requirements
+
+- Have installed [the Helm command line](https://helm.sh/docs/intro/install/)
+- Have connected/logged to a kubernetes cluster
+- Configure your Quarkus application to use any of the Quarkus Kubernetes extensions like Quarkus Kubernetes, Quarkus OpenShift or Quarkus Knative.
+- Configure your Quarkus application to use any of [the Quarkus Container Image extensions](https://quarkus.io/guides/container-image) - This example uses `container-image-docker`.
+
+# How can it be used?
+
+You can run the following Maven command in order to generate the Helm artifacts and build/push the image into a container registry:
+
+```shell
+mvn clean package -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=<your container registry> -Dquarkus.container-image.group=<your container registry namespace>
+```
+
+This command will push the image to a container registry and will become available when a pod or container is created.
+
+Finally, let's use Helm to deploy it into the cluster:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name>
+```
+
+The above command will deploy a chart using the default values (as defined within the `values.yaml` file). We can override the default values to use your `values.dev.yaml` file by executing the following command:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name> --values ./target/helm/<chart name>/kubernetes/values.dev.yaml
+```
+
+How can I update my deployment?
+
+- Via the `upgrade` option of Helm command line:
+
+After making changes to your project and regenerating the Helm resources and the application container image, then you need to upgrade your deployment:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name>
+```
+
+- Via the `set` option of Helm command line:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name> --set <app name>.replicas=1
+```
+
+How can we delete my deployment?
+
+```shell
+helm uninstall helm-example
+```

--- a/event-statistics/deploy/helm/openshift/event-statistics-java11-latest-openshift/templates/configmap.yaml
+++ b/event-statistics/deploy/helm/openshift/event-statistics-java11-latest-openshift/templates/configmap.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: event-statistics
+    application: event-stats
+    system: quarkus-super-heroes
+  name: event-statistics-config
+data:
+  kafka.bootstrap.servers: PLAINTEXT://fights-kafka:9092
+  mp.messaging.connector.smallrye-kafka.apicurio.registry.url: http://apicurio:8080/apis/registry/v2
+  quarkus.opentelemetry.tracer.exporter.otlp.endpoint: http://otel-collector:4317

--- a/event-statistics/deploy/helm/openshift/event-statistics-java11-latest-openshift/templates/deployment.yaml
+++ b/event-statistics/deploy/helm/openshift/event-statistics-java11-latest-openshift/templates/deployment.yaml
@@ -1,0 +1,112 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: fights-kafka
+    application: fights-service
+    app.kubernetes.io/part-of: fights-service
+    app.openshift.io/runtime: amq
+    system: quarkus-super-heroes
+  name: fights-kafka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: fights-kafka
+  template:
+    metadata:
+      labels:
+        application: fights-service
+        name: fights-kafka
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - command:
+            - sh
+            - -c
+            - "export CLUSTER_ID=$(bin/kafka-storage.sh random-uuid) && bin/kafka-storage.sh format -t ${CLUSTER_ID} -c config/kraft/server.properties && bin/kafka-server-start.sh config/kraft/server.properties --override advertised.listeners=${KAFKA_ADVERTISED_LISTENERS}"
+          env:
+            - name: LOG_DIR
+              value: /tmp/logs
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: PLAINTEXT://fights-kafka:9092
+          image: quay.io/strimzi/kafka:0.28.0-kafka-3.1.0
+          name: fights-kafka
+          ports:
+            - containerPort: 9092
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 128Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
+  labels:
+    app: apicurio
+    application: fights-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: fights-service
+    app.kubernetes.io/name: apicurio
+    app.kubernetes.io/version: 2.2.3.Final
+    app.openshift.io/runtime: apicurio
+  name: apicurio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: apicurio
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scheme: http
+      labels:
+        application: fights-service
+        name: apicurio
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - env:
+            - name: REGISTRY_AUTH_ANONYMOUS_READ_ACCESS_ENABLED
+              value: "true"
+          image: quay.io/apicurio/apicurio-registry-mem:2.2.3.Final
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health/live
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          name: apicurio
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health/ready
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 128Mi

--- a/event-statistics/deploy/helm/openshift/event-statistics-java11-latest-openshift/templates/deploymentconfig.yaml
+++ b/event-statistics/deploy/helm/openshift/event-statistics-java11-latest-openshift/templates/deploymentconfig.yaml
@@ -1,0 +1,102 @@
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  annotations:
+    app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "fights-kafka,apicurio,otel-collector"
+    app.openshift.io/vcs-ref: main
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:49:48 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8085"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: event-statistics
+    app.kubernetes.io/part-of: event-stats
+    app.kubernetes.io/version: java11-latest
+    app: event-statistics
+    application: event-stats
+    system: quarkus-super-heroes
+    app.openshift.io/runtime: quarkus
+  name: event-statistics
+spec:
+  replicas: 1
+  selector:
+    app.kubernetes.io/version: java11-latest
+    app.kubernetes.io/name: event-statistics
+    app.kubernetes.io/part-of: event-stats
+  template:
+    metadata:
+      annotations:
+        app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+        app.openshift.io/connects-to: "fights-kafka,apicurio,otel-collector"
+        app.openshift.io/vcs-ref: main
+        app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+        app.quarkus.io/build-timestamp: 2023-02-20 - 20:49:48 +0000
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /q/metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scheme: http
+      labels:
+        app: event-statistics
+        application: event-stats
+        system: quarkus-super-heroes
+        app.openshift.io/runtime: quarkus
+        app.kubernetes.io/version: java11-latest
+        app.kubernetes.io/name: event-statistics
+        app.kubernetes.io/part-of: event-stats
+    spec:
+      containers:
+        - env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom:
+            - secretRef:
+                name: event-statistics-config-creds
+            - configMapRef:
+                name: event-statistics-config
+          image: {{ .Values.app.image }}
+          imagePullPolicy: Always
+          livenessProbe:
+            failureThreshold: {{ .Values.app.livenessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.livenessProbe.httpGet.path }}
+              port: {{ .Values.app.livenessProbe.httpGet.port }}
+              scheme: {{ .Values.app.livenessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.livenessProbe.timeoutSeconds }}
+          name: event-statistics
+          ports:
+            - containerPort: 8085
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: {{ .Values.app.readinessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.readinessProbe.httpGet.path }}
+              port: {{ .Values.app.readinessProbe.httpGet.port }}
+              scheme: {{ .Values.app.readinessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.readinessProbe.timeoutSeconds }}
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 256Mi
+  triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+          - event-statistics
+        from:
+          kind: ImageStreamTag
+          name: event-statistics:java11-latest
+      type: ImageChange

--- a/event-statistics/deploy/helm/openshift/event-statistics-java11-latest-openshift/templates/imagestream.yaml
+++ b/event-statistics/deploy/helm/openshift/event-statistics-java11-latest-openshift/templates/imagestream.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  annotations:
+    app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "fights-kafka,apicurio,otel-collector"
+    app.openshift.io/vcs-ref: main
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:49:48 +0000
+  labels:
+    app: event-statistics
+    application: event-stats
+    system: quarkus-super-heroes
+    app.openshift.io/runtime: quarkus
+    app.kubernetes.io/version: java11-latest
+    app.kubernetes.io/name: event-statistics
+    app.kubernetes.io/part-of: event-stats
+  name: event-statistics
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+    - from:
+        kind: DockerImage
+        name: quay.io/quarkus-super-heroes/event-statistics:java11-latest
+      importPolicy: {}
+      name: java11-latest
+      referencePolicy:
+        type: Source
+    - from:
+        kind: DockerImage
+        name: quay.io/quarkus-super-heroes/event-statistics:java17-latest
+      importPolicy: {}
+      name: java17-latest
+      referencePolicy:
+        type: Source
+    - from:
+        kind: DockerImage
+        name: quay.io/quarkus-super-heroes/event-statistics:native-latest
+      importPolicy: {}
+      name: native-latest
+      referencePolicy:
+        type: Source

--- a/event-statistics/deploy/helm/openshift/event-statistics-java11-latest-openshift/templates/route.yaml
+++ b/event-statistics/deploy/helm/openshift/event-statistics-java11-latest-openshift/templates/route.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
+  labels:
+    app: apicurio
+    application: fights-service
+    system: quarkus-super-heroes
+    app.openshift.io/runtime: apicurio
+  name: apicurio
+spec:
+  port:
+    targetPort: 8080
+  to:
+    kind: Service
+    name: apicurio
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  annotations:
+    app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "fights-kafka,apicurio,otel-collector"
+    app.openshift.io/vcs-ref: main
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:49:48 +0000
+  labels:
+    app.kubernetes.io/name: event-statistics
+    app.kubernetes.io/part-of: event-stats
+    app.kubernetes.io/version: java11-latest
+    app: event-statistics
+    application: event-stats
+    system: quarkus-super-heroes
+    app.openshift.io/runtime: quarkus
+  name: event-statistics
+spec:
+  port:
+    targetPort: http
+  to:
+    kind: Service
+    name: event-statistics

--- a/event-statistics/deploy/helm/openshift/event-statistics-java11-latest-openshift/templates/secret.yaml
+++ b/event-statistics/deploy/helm/openshift/event-statistics-java11-latest-openshift/templates/secret.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: event-statistics
+    application: event-stats
+    system: quarkus-super-heroes
+  name: event-statistics-config-creds
+type: Opaque

--- a/event-statistics/deploy/helm/openshift/event-statistics-java11-latest-openshift/templates/service.yaml
+++ b/event-statistics/deploy/helm/openshift/event-statistics-java11-latest-openshift/templates/service.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: fights-kafka
+    application: fights-service
+    system: quarkus-super-heroes
+  name: fights-kafka
+spec:
+  ports:
+    - port: 9092
+      protocol: TCP
+      targetPort: 9092
+  selector:
+    name: fights-kafka
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
+  labels:
+    name: apicurio
+    application: fights-service
+    system: quarkus-super-heroes
+  name: apicurio
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    name: apicurio
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "fights-kafka,apicurio,otel-collector"
+    app.openshift.io/vcs-ref: main
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:49:48 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8085"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: event-statistics
+    app.kubernetes.io/part-of: event-stats
+    app.kubernetes.io/version: java11-latest
+    app: event-statistics
+    application: event-stats
+    system: quarkus-super-heroes
+    app.openshift.io/runtime: quarkus
+  name: event-statistics
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8085
+  selector:
+    app.kubernetes.io/name: event-statistics
+    app.kubernetes.io/part-of: event-stats
+    app.kubernetes.io/version: java11-latest
+  type: {{ .Values.app.serviceType }}

--- a/event-statistics/deploy/helm/openshift/event-statistics-java11-latest-openshift/values.yaml
+++ b/event-statistics/deploy/helm/openshift/event-statistics-java11-latest-openshift/values.yaml
@@ -1,0 +1,24 @@
+---
+app:
+  serviceType: ClusterIP
+  livenessProbe:
+    failureThreshold: 3
+    periodSeconds: 10
+    timeoutSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/live
+      scheme: HTTP
+      port: 8085
+  image: quay.io/quarkus-super-heroes/event-statistics:java11-latest
+  readinessProbe:
+    failureThreshold: 3
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/ready
+      scheme: HTTP
+      port: 8085

--- a/event-statistics/pom.xml
+++ b/event-statistics/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.quarkus.sample.super-heroes</groupId>
   <artifactId>event-statistics</artifactId>
-  <version>1.0</version>
+  <version>java11-latest</version>
   <name>Quarkus Sample :: Super-Heroes :: Statistics Microservice</name>
   <properties>
     <assertj.version>3.24.2</assertj.version>
@@ -86,6 +86,11 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-opentelemetry</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkiverse.helm</groupId>
+      <artifactId>quarkus-helm</artifactId>
+      <version>0.2.5</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/Chart.yaml
+++ b/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/Chart.yaml
@@ -1,0 +1,4 @@
+---
+name: rest-fights-java11-latest-knative
+version: 1.0.0
+apiVersion: v2

--- a/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/charts/rest-heroes-java11-latest-knative/Chart.yaml
+++ b/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/charts/rest-heroes-java11-latest-knative/Chart.yaml
@@ -1,0 +1,4 @@
+---
+name: rest-heroes-java11-latest-knative
+version: 1.0.0
+apiVersion: v2

--- a/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/charts/rest-heroes-java11-latest-knative/templates/NOTES.txt
+++ b/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/charts/rest-heroes-java11-latest-knative/templates/NOTES.txt
@@ -1,0 +1,72 @@
+# Quarkus Helm Notes
+
+To access the Helm annotations or properties you just need to have the following dependency in your
+class path:
+
+    <dependency>
+        <groupId>io.quarkiverse.helm</groupId>
+        <artifactId>quarkus-helm</artifactId>
+        <version>{quarkus-helm-version}</version>
+    </dependency>
+
+Build the project using:
+
+    mvn clean package
+
+You can find the generated Helm artifacts under: `target/helm/kubernetes/<chart name>/` that should look like:
+- Chart.yaml
+- values.yaml
+- templates/*.yml the generated resources by Quarkus Helm
+
+**Note**: The `<chart name>` is set from either the property `quarkus.helm.name` or the `@HelmChart` annotation or the Quarkus application.
+
+# Requirements
+
+- Have installed [the Helm command line](https://helm.sh/docs/intro/install/)
+- Have connected/logged to a kubernetes cluster
+- Configure your Quarkus application to use any of the Quarkus Kubernetes extensions like Quarkus Kubernetes, Quarkus OpenShift or Quarkus Knative.
+- Configure your Quarkus application to use any of [the Quarkus Container Image extensions](https://quarkus.io/guides/container-image) - This example uses `container-image-docker`.
+
+# How can it be used?
+
+You can run the following Maven command in order to generate the Helm artifacts and build/push the image into a container registry:
+
+```shell
+mvn clean package -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=<your container registry> -Dquarkus.container-image.group=<your container registry namespace>
+```
+
+This command will push the image to a container registry and will become available when a pod or container is created.
+
+Finally, let's use Helm to deploy it into the cluster:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name>
+```
+
+The above command will deploy a chart using the default values (as defined within the `values.yaml` file). We can override the default values to use your `values.dev.yaml` file by executing the following command:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name> --values ./target/helm/<chart name>/kubernetes/values.dev.yaml
+```
+
+How can I update my deployment?
+
+- Via the `upgrade` option of Helm command line:
+
+After making changes to your project and regenerating the Helm resources and the application container image, then you need to upgrade your deployment:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name>
+```
+
+- Via the `set` option of Helm command line:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name> --set <app name>.replicas=1
+```
+
+How can we delete my deployment?
+
+```shell
+helm uninstall helm-example
+```

--- a/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/charts/rest-heroes-java11-latest-knative/templates/configmap.yaml
+++ b/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/charts/rest-heroes-java11-latest-knative/templates/configmap.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: rest-heroes-config
+data:
+  quarkus.hibernate-orm.database.generation: validate
+  quarkus.hibernate-orm.sql-load-script: no-file
+  quarkus.datasource.reactive.url: postgresql://heroes-db:5432/heroes_database
+  quarkus.opentelemetry.tracer.exporter.otlp.endpoint: http://otel-collector:4317
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: heroes-db-init
+data:
+  get-data.sh: |-
+    #!/bin/bash
+
+    curl https://raw.githubusercontent.com/quarkusio/quarkus-super-heroes/main/rest-heroes/deploy/db-init/initialize-tables.sql --output /docker-entrypoint-initdb.d/1-init-tables.sql

--- a/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/charts/rest-heroes-java11-latest-knative/templates/deployment.yaml
+++ b/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/charts/rest-heroes-java11-latest-knative/templates/deployment.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: heroes-service
+    app.openshift.io/runtime: postgresql
+  name: heroes-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: heroes-db
+  template:
+    metadata:
+      labels:
+        name: heroes-db
+        application: heroes-service
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - envFrom:
+            - secretRef:
+                name: heroes-db-config
+          image: bitnami/postgresql:14
+          name: heroes-db
+          ports:
+            - containerPort: 5432
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              memory: 32Mi
+          volumeMounts:
+            - mountPath: /bitnami/postgresql
+              name: heroes-db-data
+            - mountPath: /docker-entrypoint-initdb.d
+              name: heroes-db-init-data
+      initContainers:
+        - command:
+            - sh
+            - get-data.sh
+          image: registry.access.redhat.com/ubi8-minimal:8.6
+          name: get-data
+          volumeMounts:
+            - mountPath: /docker-entrypoint-preinitdb.d
+              name: heroes-db-init
+            - mountPath: /docker-entrypoint-initdb.d
+              name: heroes-db-init-data
+          workingDir: /docker-entrypoint-preinitdb.d
+      volumes:
+        - emptyDir: {}
+          name: heroes-db-data
+        - emptyDir: {}
+          name: heroes-db-init-data
+        - configMap:
+            name: heroes-db-init
+          name: heroes-db-init

--- a/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/charts/rest-heroes-java11-latest-knative/templates/secret.yaml
+++ b/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/charts/rest-heroes-java11-latest-knative/templates/secret.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: rest-heroes-config-creds
+data:
+  quarkus.datasource.username: c3VwZXJtYW4=
+  quarkus.datasource.password: c3VwZXJtYW4=
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: heroes-db-config
+data:
+  POSTGRESQL_DATABASE: aGVyb2VzX2RhdGFiYXNl
+  POSTGRESQL_USERNAME: c3VwZXJtYW4=
+  POSTGRESQL_PASSWORD: c3VwZXJtYW4=
+type: Opaque

--- a/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/charts/rest-heroes-java11-latest-knative/templates/service.yaml
+++ b/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/charts/rest-heroes-java11-latest-knative/templates/service.yaml
@@ -1,0 +1,81 @@
+---
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  annotations:
+    app.openshift.io/connects-to: "heroes-db,otel-collector"
+    app.openshift.io/vcs-ref: main
+    app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:50:59 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8083"
+    prometheus.io/scheme: http
+  labels:
+    app: rest-heroes
+    app.openshift.io/runtime: quarkus
+    application: heroes-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/version: java11-latest
+    app.kubernetes.io/name: rest-heroes
+    app.kubernetes.io/part-of: heroes-service
+  name: rest-heroes
+spec:
+  template:
+    spec:
+      containers:
+        - envFrom:
+            - configMapRef:
+                name: rest-heroes-config
+            - secretRef:
+                name: rest-heroes-config-creds
+          image: {{ .Values.app.image }}
+          imagePullPolicy: Always
+          livenessProbe:
+            failureThreshold: {{ .Values.app.livenessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.livenessProbe.httpGet.path }}
+              port: {{ .Values.app.livenessProbe.httpGet.port }}
+              scheme: {{ .Values.app.livenessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.livenessProbe.timeoutSeconds }}
+          name: rest-heroes
+          ports:
+            - containerPort: 8083
+              name: http1
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: {{ .Values.app.readinessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.readinessProbe.httpGet.path }}
+              port: {{ .Values.app.readinessProbe.httpGet.port }}
+              scheme: {{ .Values.app.readinessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.readinessProbe.timeoutSeconds }}
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: heroes-db
+spec:
+  ports:
+    - port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    name: heroes-db
+  type: ClusterIP

--- a/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/charts/rest-heroes-java11-latest-knative/values.yaml
+++ b/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/charts/rest-heroes-java11-latest-knative/values.yaml
@@ -1,0 +1,24 @@
+---
+app:
+  serviceType: ClusterIP
+  livenessProbe:
+    failureThreshold: 3
+    periodSeconds: 10
+    timeoutSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/live
+      scheme: HTTP
+      port: ":START:{{ .Values.app.livenessProbe.httpGet.port }}:END:"
+  image: rest-heroes:java11-latest
+  readinessProbe:
+    failureThreshold: 3
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/ready
+      scheme: HTTP
+      port: ":START:{{ .Values.app.readinessProbe.httpGet.port }}:END:"

--- a/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/charts/rest-villains-java11-latest-knative/Chart.yaml
+++ b/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/charts/rest-villains-java11-latest-knative/Chart.yaml
@@ -1,0 +1,4 @@
+---
+name: rest-villains-java11-latest-knative
+version: 1.0.0
+apiVersion: v2

--- a/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/charts/rest-villains-java11-latest-knative/templates/NOTES.txt
+++ b/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/charts/rest-villains-java11-latest-knative/templates/NOTES.txt
@@ -1,0 +1,72 @@
+# Quarkus Helm Notes
+
+To access the Helm annotations or properties you just need to have the following dependency in your
+class path:
+
+    <dependency>
+        <groupId>io.quarkiverse.helm</groupId>
+        <artifactId>quarkus-helm</artifactId>
+        <version>{quarkus-helm-version}</version>
+    </dependency>
+
+Build the project using:
+
+    mvn clean package
+
+You can find the generated Helm artifacts under: `target/helm/kubernetes/<chart name>/` that should look like:
+- Chart.yaml
+- values.yaml
+- templates/*.yml the generated resources by Quarkus Helm
+
+**Note**: The `<chart name>` is set from either the property `quarkus.helm.name` or the `@HelmChart` annotation or the Quarkus application.
+
+# Requirements
+
+- Have installed [the Helm command line](https://helm.sh/docs/intro/install/)
+- Have connected/logged to a kubernetes cluster
+- Configure your Quarkus application to use any of the Quarkus Kubernetes extensions like Quarkus Kubernetes, Quarkus OpenShift or Quarkus Knative.
+- Configure your Quarkus application to use any of [the Quarkus Container Image extensions](https://quarkus.io/guides/container-image) - This example uses `container-image-docker`.
+
+# How can it be used?
+
+You can run the following Maven command in order to generate the Helm artifacts and build/push the image into a container registry:
+
+```shell
+mvn clean package -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=<your container registry> -Dquarkus.container-image.group=<your container registry namespace>
+```
+
+This command will push the image to a container registry and will become available when a pod or container is created.
+
+Finally, let's use Helm to deploy it into the cluster:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name>
+```
+
+The above command will deploy a chart using the default values (as defined within the `values.yaml` file). We can override the default values to use your `values.dev.yaml` file by executing the following command:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name> --values ./target/helm/<chart name>/kubernetes/values.dev.yaml
+```
+
+How can I update my deployment?
+
+- Via the `upgrade` option of Helm command line:
+
+After making changes to your project and regenerating the Helm resources and the application container image, then you need to upgrade your deployment:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name>
+```
+
+- Via the `set` option of Helm command line:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name> --set <app name>.replicas=1
+```
+
+How can we delete my deployment?
+
+```shell
+helm uninstall helm-example
+```

--- a/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/charts/rest-villains-java11-latest-knative/templates/configmap.yaml
+++ b/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/charts/rest-villains-java11-latest-knative/templates/configmap.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+  name: rest-villains-config
+data:
+  quarkus.hibernate-orm.database.generation: validate
+  quarkus.hibernate-orm.sql-load-script: no-file
+  quarkus.datasource.jdbc.url: jdbc:otel:postgresql://villains-db:5432/villains_database
+  quarkus.opentelemetry.tracer.exporter.otlp.endpoint: http://otel-collector:4317
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+  name: villains-db-init
+data:
+  get-data.sh: |-
+    #!/bin/bash
+
+    curl https://raw.githubusercontent.com/quarkusio/quarkus-super-heroes/main/rest-villains/deploy/db-init/initialize-tables.sql --output /docker-entrypoint-initdb.d/1-init-tables.sql

--- a/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/charts/rest-villains-java11-latest-knative/templates/deployment.yaml
+++ b/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/charts/rest-villains-java11-latest-knative/templates/deployment.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: villains-service
+    app.openshift.io/runtime: postgresql
+  name: villains-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: villains-db
+  template:
+    metadata:
+      labels:
+        application: villains-service
+        name: villains-db
+    spec:
+      containers:
+        - envFrom:
+            - secretRef:
+                name: villains-db-config
+          image: bitnami/postgresql:14
+          name: villains-db
+          ports:
+            - containerPort: 5432
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              memory: 32Mi
+          volumeMounts:
+            - mountPath: /bitnami/postgresql
+              name: villains-db-data
+            - mountPath: /docker-entrypoint-initdb.d
+              name: villains-db-init-data
+      initContainers:
+        - command:
+            - sh
+            - get-data.sh
+          image: registry.access.redhat.com/ubi8-minimal:8.6
+          name: get-data
+          volumeMounts:
+            - mountPath: /docker-entrypoint-preinitdb.d
+              name: villains-db-init
+            - mountPath: /docker-entrypoint-initdb.d
+              name: villains-db-init-data
+          workingDir: /docker-entrypoint-preinitdb.d
+      volumes:
+        - emptyDir: {}
+          name: villains-db-data
+        - emptyDir: {}
+          name: villains-db-init-data
+        - configMap:
+            name: villains-db-init
+          name: villains-db-init

--- a/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/charts/rest-villains-java11-latest-knative/templates/secret.yaml
+++ b/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/charts/rest-villains-java11-latest-knative/templates/secret.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+  name: rest-villains-config-creds
+data:
+  quarkus.datasource.username: c3VwZXJiYWQ=
+  quarkus.datasource.password: c3VwZXJiYWQ=
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+  name: villains-db-config
+data:
+  POSTGRESQL_DATABASE: dmlsbGFpbnNfZGF0YWJhc2U=
+  POSTGRESQL_USERNAME: c3VwZXJiYWQ=
+  POSTGRESQL_PASSWORD: c3VwZXJiYWQ=
+type: Opaque

--- a/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/charts/rest-villains-java11-latest-knative/templates/service.yaml
+++ b/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/charts/rest-villains-java11-latest-knative/templates/service.yaml
@@ -1,0 +1,81 @@
+---
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  annotations:
+    app.openshift.io/connects-to: "villains-db,otel-collector"
+    app.openshift.io/vcs-ref: main
+    app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:50:18 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8084"
+    prometheus.io/scheme: http
+  labels:
+    app: rest-villains
+    app.openshift.io/runtime: quarkus
+    application: villains-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/version: java11-latest
+    app.kubernetes.io/name: rest-villains
+    app.kubernetes.io/part-of: villains-service
+  name: rest-villains
+spec:
+  template:
+    spec:
+      containers:
+        - envFrom:
+            - secretRef:
+                name: rest-villains-config-creds
+            - configMapRef:
+                name: rest-villains-config
+          image: {{ .Values.app.image }}
+          imagePullPolicy: Always
+          livenessProbe:
+            failureThreshold: {{ .Values.app.livenessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.livenessProbe.httpGet.path }}
+              port: {{ .Values.app.livenessProbe.httpGet.port }}
+              scheme: {{ .Values.app.livenessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.livenessProbe.timeoutSeconds }}
+          name: rest-villains
+          ports:
+            - containerPort: 8084
+              name: http1
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: {{ .Values.app.readinessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.readinessProbe.httpGet.path }}
+              port: {{ .Values.app.readinessProbe.httpGet.port }}
+              scheme: {{ .Values.app.readinessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.readinessProbe.timeoutSeconds }}
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+  name: villains-db
+spec:
+  ports:
+    - port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    name: villains-db
+  type: ClusterIP

--- a/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/charts/rest-villains-java11-latest-knative/values.yaml
+++ b/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/charts/rest-villains-java11-latest-knative/values.yaml
@@ -1,0 +1,24 @@
+---
+app:
+  serviceType: ClusterIP
+  livenessProbe:
+    failureThreshold: 3
+    periodSeconds: 10
+    timeoutSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/live
+      scheme: HTTP
+      port: ":START:{{ .Values.app.livenessProbe.httpGet.port }}:END:"
+  image: rest-villains:java11-latest
+  readinessProbe:
+    failureThreshold: 3
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/ready
+      scheme: HTTP
+      port: ":START:{{ .Values.app.readinessProbe.httpGet.port }}:END:"

--- a/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/templates/NOTES.txt
+++ b/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/templates/NOTES.txt
@@ -1,0 +1,72 @@
+# Quarkus Helm Notes
+
+To access the Helm annotations or properties you just need to have the following dependency in your
+class path:
+
+    <dependency>
+        <groupId>io.quarkiverse.helm</groupId>
+        <artifactId>quarkus-helm</artifactId>
+        <version>{quarkus-helm-version}</version>
+    </dependency>
+
+Build the project using:
+
+    mvn clean package
+
+You can find the generated Helm artifacts under: `target/helm/kubernetes/<chart name>/` that should look like:
+- Chart.yaml
+- values.yaml
+- templates/*.yml the generated resources by Quarkus Helm
+
+**Note**: The `<chart name>` is set from either the property `quarkus.helm.name` or the `@HelmChart` annotation or the Quarkus application.
+
+# Requirements
+
+- Have installed [the Helm command line](https://helm.sh/docs/intro/install/)
+- Have connected/logged to a kubernetes cluster
+- Configure your Quarkus application to use any of the Quarkus Kubernetes extensions like Quarkus Kubernetes, Quarkus OpenShift or Quarkus Knative.
+- Configure your Quarkus application to use any of [the Quarkus Container Image extensions](https://quarkus.io/guides/container-image) - This example uses `container-image-docker`.
+
+# How can it be used?
+
+You can run the following Maven command in order to generate the Helm artifacts and build/push the image into a container registry:
+
+```shell
+mvn clean package -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=<your container registry> -Dquarkus.container-image.group=<your container registry namespace>
+```
+
+This command will push the image to a container registry and will become available when a pod or container is created.
+
+Finally, let's use Helm to deploy it into the cluster:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name>
+```
+
+The above command will deploy a chart using the default values (as defined within the `values.yaml` file). We can override the default values to use your `values.dev.yaml` file by executing the following command:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name> --values ./target/helm/<chart name>/kubernetes/values.dev.yaml
+```
+
+How can I update my deployment?
+
+- Via the `upgrade` option of Helm command line:
+
+After making changes to your project and regenerating the Helm resources and the application container image, then you need to upgrade your deployment:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name>
+```
+
+- Via the `set` option of Helm command line:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name> --set <app name>.replicas=1
+```
+
+How can we delete my deployment?
+
+```shell
+helm uninstall helm-example
+```

--- a/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/templates/configmap.yaml
+++ b/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/templates/configmap.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: rest-fights
+    application: fights-service
+    system: quarkus-super-heroes
+  name: rest-fights-config
+data:
+  quarkus.liquibase-mongodb.migrate-at-start: "false"
+  quarkus.mongodb.hosts: fights-db:27017
+  quarkus.stork.hero-service.service-discovery.type: kubernetes
+  quarkus.stork.hero-service.service-discovery.application: rest-heroes
+  quarkus.stork.hero-service.service-discovery.refresh-period: 1M
+  quarkus.stork.villain-service.service-discovery.type: kubernetes
+  quarkus.stork.villain-service.service-discovery.application: rest-villains
+  quarkus.stork.villain-service.service-discovery.refresh-period: 1M
+  quarkus.opentelemetry.tracer.exporter.otlp.endpoint: http://otel-collector:4317
+  kafka.bootstrap.servers: PLAINTEXT://fights-kafka:9092
+  mp.messaging.connector.smallrye-kafka.apicurio.registry.url: http://apicurio:8080/apis/registry/v2

--- a/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/templates/deployment.yaml
+++ b/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/templates/deployment.yaml
@@ -1,0 +1,148 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: fights-db
+    application: fights-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: fights-service
+    app.openshift.io/runtime: mongodb
+  name: fights-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: fights-db
+  template:
+    metadata:
+      labels:
+        application: fights-service
+        name: fights-db
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - envFrom:
+            - secretRef:
+                name: fights-db-config
+          image: bitnami/mongodb:5.0
+          name: fights-db
+          ports:
+            - containerPort: 27017
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              memory: 64Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: fights-kafka
+    application: fights-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: fights-service
+    app.openshift.io/runtime: amq
+  name: fights-kafka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: fights-kafka
+  template:
+    metadata:
+      labels:
+        application: fights-service
+        name: fights-kafka
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - command:
+            - sh
+            - -c
+            - "export CLUSTER_ID=$(bin/kafka-storage.sh random-uuid) && bin/kafka-storage.sh format -t ${CLUSTER_ID} -c config/kraft/server.properties && bin/kafka-server-start.sh config/kraft/server.properties --override advertised.listeners=${KAFKA_ADVERTISED_LISTENERS}"
+          env:
+            - name: LOG_DIR
+              value: /tmp/logs
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: PLAINTEXT://fights-kafka:9092
+          image: quay.io/strimzi/kafka:0.28.0-kafka-3.1.0
+          name: fights-kafka
+          ports:
+            - containerPort: 9092
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 128Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
+  labels:
+    app: apicurio
+    application: fights-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: fights-service
+    app.kubernetes.io/name: apicurio
+    app.kubernetes.io/version: 2.2.3.Final
+    app.openshift.io/runtime: apicurio
+  name: apicurio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: apicurio
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scheme: http
+      labels:
+        application: fights-service
+        name: apicurio
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - env:
+            - name: REGISTRY_AUTH_ANONYMOUS_READ_ACCESS_ENABLED
+              value: "true"
+          image: quay.io/apicurio/apicurio-registry-mem:2.2.3.Final
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health/live
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          name: apicurio
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health/ready
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 128Mi

--- a/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/templates/rolebinding.yaml
+++ b/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/templates/rolebinding.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: default_view
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: default

--- a/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/templates/secret.yaml
+++ b/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/templates/secret.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: rest-fights
+    application: fights-service
+    system: quarkus-super-heroes
+  name: rest-fights-config-creds
+data:
+  quarkus.mongodb.credentials.username: c3VwZXJmaWdodA==
+  quarkus.mongodb.credentials.password: c3VwZXJmaWdodA==
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: fights-db
+    application: fights-service
+    system: quarkus-super-heroes
+  name: fights-db-config
+data:
+  MONGODB_DATABASE: ZmlnaHRz
+  MONGODB_USERNAME: c3VwZXJmaWdodA==
+  MONGODB_PASSWORD: c3VwZXJmaWdodA==
+  MONGODB_ROOT_USER: c3VwZXI=
+  MONGODB_ROOT_PASSWORD: c3VwZXI=
+type: Opaque

--- a/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/templates/service.yaml
+++ b/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/templates/service.yaml
@@ -1,0 +1,134 @@
+---
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  annotations:
+    app.openshift.io/connects-to: "fights-db,fights-kafka,apicurio,rest-villains,rest-heroes,otel-collector"
+    app.openshift.io/vcs-ref: main
+    app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:51:43 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8082"
+    prometheus.io/scheme: http
+  labels:
+    app: rest-fights
+    app.openshift.io/runtime: quarkus
+    application: fights-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: fights-service
+    app.kubernetes.io/name: rest-fights
+    app.kubernetes.io/version: java11-latest
+  name: rest-fights
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: "1"
+        app.openshift.io/connects-to: "fights-db,fights-kafka,apicurio,rest-villains,rest-heroes,otel-collector"
+        app.openshift.io/vcs-ref: main
+        app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+      labels:
+        app: rest-fights
+        app.openshift.io/runtime: quarkus
+        application: fights-service
+        system: quarkus-super-heroes
+        app.kubernetes.io/part-of: fights-service
+        app.kubernetes.io/name: rest-fights
+        app.kubernetes.io/version: java11-latest
+    spec:
+      containers:
+        - envFrom:
+            - secretRef:
+                name: rest-fights-config-creds
+            - configMapRef:
+                name: rest-fights-config
+          image: {{ .Values.app.image }}
+          imagePullPolicy: Always
+          livenessProbe:
+            failureThreshold: {{ .Values.app.livenessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.livenessProbe.httpGet.path }}
+              port: {{ .Values.app.livenessProbe.httpGet.port }}
+              scheme: {{ .Values.app.livenessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.livenessProbe.timeoutSeconds }}
+          name: rest-fights
+          ports:
+            - containerPort: 8082
+              name: http1
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: {{ .Values.app.readinessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.readinessProbe.httpGet.path }}
+              port: {{ .Values.app.readinessProbe.httpGet.port }}
+              scheme: {{ .Values.app.readinessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.readinessProbe.timeoutSeconds }}
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: fights-db
+    application: fights-service
+    system: quarkus-super-heroes
+  name: fights-db
+spec:
+  ports:
+    - port: 27017
+      protocol: TCP
+      targetPort: 27017
+  selector:
+    name: fights-db
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: fights-kafka
+    application: fights-service
+    system: quarkus-super-heroes
+  name: fights-kafka
+spec:
+  ports:
+    - port: 9092
+      protocol: TCP
+      targetPort: 9092
+  selector:
+    name: fights-kafka
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
+  labels:
+    name: apicurio
+    application: fights-service
+    system: quarkus-super-heroes
+  name: apicurio
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    name: apicurio
+  type: ClusterIP

--- a/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/values.yaml
+++ b/rest-fights/deploy/helm/knative/rest-fights-java11-latest-knative/values.yaml
@@ -1,0 +1,24 @@
+---
+app:
+  serviceType: ClusterIP
+  livenessProbe:
+    failureThreshold: 3
+    periodSeconds: 10
+    timeoutSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/live
+      scheme: HTTP
+      port: ":START:{{ .Values.app.livenessProbe.httpGet.port }}:END:"
+  image: quay.io/quarkus-super-heroes/rest-fights:java11-latest
+  readinessProbe:
+    failureThreshold: 3
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/ready
+      scheme: HTTP
+      port: ":START:{{ .Values.app.readinessProbe.httpGet.port }}:END:"

--- a/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/Chart.yaml
+++ b/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/Chart.yaml
@@ -1,0 +1,4 @@
+---
+name: rest-fights-java11-latest-kubernetes
+version: 1.0.0
+apiVersion: v2

--- a/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/charts/rest-heroes-java11-latest-kubernetes/Chart.yaml
+++ b/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/charts/rest-heroes-java11-latest-kubernetes/Chart.yaml
@@ -1,0 +1,4 @@
+---
+name: rest-heroes-java11-latest-kubernetes
+version: 1.0.0
+apiVersion: v2

--- a/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/charts/rest-heroes-java11-latest-kubernetes/templates/NOTES.txt
+++ b/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/charts/rest-heroes-java11-latest-kubernetes/templates/NOTES.txt
@@ -1,0 +1,72 @@
+# Quarkus Helm Notes
+
+To access the Helm annotations or properties you just need to have the following dependency in your
+class path:
+
+    <dependency>
+        <groupId>io.quarkiverse.helm</groupId>
+        <artifactId>quarkus-helm</artifactId>
+        <version>{quarkus-helm-version}</version>
+    </dependency>
+
+Build the project using:
+
+    mvn clean package
+
+You can find the generated Helm artifacts under: `target/helm/kubernetes/<chart name>/` that should look like:
+- Chart.yaml
+- values.yaml
+- templates/*.yml the generated resources by Quarkus Helm
+
+**Note**: The `<chart name>` is set from either the property `quarkus.helm.name` or the `@HelmChart` annotation or the Quarkus application.
+
+# Requirements
+
+- Have installed [the Helm command line](https://helm.sh/docs/intro/install/)
+- Have connected/logged to a kubernetes cluster
+- Configure your Quarkus application to use any of the Quarkus Kubernetes extensions like Quarkus Kubernetes, Quarkus OpenShift or Quarkus Knative.
+- Configure your Quarkus application to use any of [the Quarkus Container Image extensions](https://quarkus.io/guides/container-image) - This example uses `container-image-docker`.
+
+# How can it be used?
+
+You can run the following Maven command in order to generate the Helm artifacts and build/push the image into a container registry:
+
+```shell
+mvn clean package -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=<your container registry> -Dquarkus.container-image.group=<your container registry namespace>
+```
+
+This command will push the image to a container registry and will become available when a pod or container is created.
+
+Finally, let's use Helm to deploy it into the cluster:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name>
+```
+
+The above command will deploy a chart using the default values (as defined within the `values.yaml` file). We can override the default values to use your `values.dev.yaml` file by executing the following command:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name> --values ./target/helm/<chart name>/kubernetes/values.dev.yaml
+```
+
+How can I update my deployment?
+
+- Via the `upgrade` option of Helm command line:
+
+After making changes to your project and regenerating the Helm resources and the application container image, then you need to upgrade your deployment:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name>
+```
+
+- Via the `set` option of Helm command line:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name> --set <app name>.replicas=1
+```
+
+How can we delete my deployment?
+
+```shell
+helm uninstall helm-example
+```

--- a/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/charts/rest-heroes-java11-latest-kubernetes/templates/configmap.yaml
+++ b/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/charts/rest-heroes-java11-latest-kubernetes/templates/configmap.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: rest-heroes-config
+data:
+  quarkus.hibernate-orm.database.generation: validate
+  quarkus.hibernate-orm.sql-load-script: no-file
+  quarkus.datasource.reactive.url: postgresql://heroes-db:5432/heroes_database
+  quarkus.opentelemetry.tracer.exporter.otlp.endpoint: http://otel-collector:4317
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: heroes-db-init
+data:
+  get-data.sh: |-
+    #!/bin/bash
+
+    curl https://raw.githubusercontent.com/quarkusio/quarkus-super-heroes/main/rest-heroes/deploy/db-init/initialize-tables.sql --output /docker-entrypoint-initdb.d/1-init-tables.sql

--- a/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/charts/rest-heroes-java11-latest-kubernetes/templates/deployment.yaml
+++ b/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/charts/rest-heroes-java11-latest-kubernetes/templates/deployment.yaml
@@ -1,0 +1,153 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    app.openshift.io/connects-to: "heroes-db,otel-collector"
+    app.quarkus.io/vcs-ref: main
+    app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:43:47 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8083"
+    prometheus.io/scheme: http
+  labels:
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/version: java11-latest
+    app.kubernetes.io/part-of: heroes-service
+    app.kubernetes.io/name: rest-heroes
+  name: rest-heroes
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/version: java11-latest
+      app.kubernetes.io/part-of: heroes-service
+      app.kubernetes.io/name: rest-heroes
+  template:
+    metadata:
+      annotations:
+        app.openshift.io/connects-to: "heroes-db,otel-collector"
+        app.quarkus.io/vcs-ref: main
+        app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+        app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+        app.quarkus.io/build-timestamp: 2023-02-20 - 20:43:47 +0000
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /q/metrics
+        prometheus.io/port: "8083"
+        prometheus.io/scheme: http
+      labels:
+        app: rest-heroes
+        application: heroes-service
+        system: quarkus-super-heroes
+        app.kubernetes.io/version: java11-latest
+        app.kubernetes.io/part-of: heroes-service
+        app.kubernetes.io/name: rest-heroes
+    spec:
+      containers:
+        - env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom:
+            - configMapRef:
+                name: rest-heroes-config
+            - secretRef:
+                name: rest-heroes-config-creds
+          image: {{ .Values.app.image }}
+          imagePullPolicy: Always
+          livenessProbe:
+            failureThreshold: {{ .Values.app.livenessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.livenessProbe.httpGet.path }}
+              port: {{ .Values.app.livenessProbe.httpGet.port }}
+              scheme: {{ .Values.app.livenessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.livenessProbe.timeoutSeconds }}
+          name: rest-heroes
+          ports:
+            - containerPort: 8083
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: {{ .Values.app.readinessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.readinessProbe.httpGet.path }}
+              port: {{ .Values.app.readinessProbe.httpGet.port }}
+              scheme: {{ .Values.app.readinessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.readinessProbe.timeoutSeconds }}
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 256Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: heroes-service
+    app.openshift.io/runtime: postgresql
+  name: heroes-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: heroes-db
+  template:
+    metadata:
+      labels:
+        name: heroes-db
+        application: heroes-service
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - envFrom:
+            - secretRef:
+                name: heroes-db-config
+          image: bitnami/postgresql:14
+          name: heroes-db
+          ports:
+            - containerPort: 5432
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              memory: 32Mi
+          volumeMounts:
+            - mountPath: /bitnami/postgresql
+              name: heroes-db-data
+            - mountPath: /docker-entrypoint-initdb.d
+              name: heroes-db-init-data
+      initContainers:
+        - command:
+            - sh
+            - get-data.sh
+          image: registry.access.redhat.com/ubi8-minimal:8.6
+          name: get-data
+          volumeMounts:
+            - mountPath: /docker-entrypoint-preinitdb.d
+              name: heroes-db-init
+            - mountPath: /docker-entrypoint-initdb.d
+              name: heroes-db-init-data
+          workingDir: /docker-entrypoint-preinitdb.d
+      volumes:
+        - emptyDir: {}
+          name: heroes-db-data
+        - emptyDir: {}
+          name: heroes-db-init-data
+        - configMap:
+            name: heroes-db-init
+          name: heroes-db-init

--- a/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/charts/rest-heroes-java11-latest-kubernetes/templates/secret.yaml
+++ b/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/charts/rest-heroes-java11-latest-kubernetes/templates/secret.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: rest-heroes-config-creds
+data:
+  quarkus.datasource.username: c3VwZXJtYW4=
+  quarkus.datasource.password: c3VwZXJtYW4=
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: heroes-db-config
+data:
+  POSTGRESQL_DATABASE: aGVyb2VzX2RhdGFiYXNl
+  POSTGRESQL_USERNAME: c3VwZXJtYW4=
+  POSTGRESQL_PASSWORD: c3VwZXJtYW4=
+type: Opaque

--- a/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/charts/rest-heroes-java11-latest-kubernetes/templates/service.yaml
+++ b/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/charts/rest-heroes-java11-latest-kubernetes/templates/service.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: heroes-db
+spec:
+  ports:
+    - port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    name: heroes-db
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    app.openshift.io/connects-to: "heroes-db,otel-collector"
+    app.quarkus.io/vcs-ref: main
+    app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:43:47 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8083"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: rest-heroes
+    app.kubernetes.io/part-of: heroes-service
+    app.kubernetes.io/version: java11-latest
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: rest-heroes
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8083
+  selector:
+    app.kubernetes.io/name: rest-heroes
+    app.kubernetes.io/part-of: heroes-service
+    app.kubernetes.io/version: java11-latest
+  type: {{ .Values.app.serviceType }}

--- a/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/charts/rest-heroes-java11-latest-kubernetes/values.yaml
+++ b/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/charts/rest-heroes-java11-latest-kubernetes/values.yaml
@@ -1,0 +1,24 @@
+---
+app:
+  serviceType: ClusterIP
+  livenessProbe:
+    failureThreshold: 3
+    periodSeconds: 10
+    timeoutSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/live
+      scheme: HTTP
+      port: 8083
+  image: quay.io/quarkus-super-heroes/rest-heroes:java11-latest
+  readinessProbe:
+    failureThreshold: 3
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/ready
+      scheme: HTTP
+      port: 8083

--- a/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/charts/rest-villains-java11-latest-kubernetes/Chart.yaml
+++ b/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/charts/rest-villains-java11-latest-kubernetes/Chart.yaml
@@ -1,0 +1,4 @@
+---
+name: rest-villains-java11-latest-kubernetes
+version: 1.0.0
+apiVersion: v2

--- a/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/charts/rest-villains-java11-latest-kubernetes/templates/NOTES.txt
+++ b/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/charts/rest-villains-java11-latest-kubernetes/templates/NOTES.txt
@@ -1,0 +1,72 @@
+# Quarkus Helm Notes
+
+To access the Helm annotations or properties you just need to have the following dependency in your
+class path:
+
+    <dependency>
+        <groupId>io.quarkiverse.helm</groupId>
+        <artifactId>quarkus-helm</artifactId>
+        <version>{quarkus-helm-version}</version>
+    </dependency>
+
+Build the project using:
+
+    mvn clean package
+
+You can find the generated Helm artifacts under: `target/helm/kubernetes/<chart name>/` that should look like:
+- Chart.yaml
+- values.yaml
+- templates/*.yml the generated resources by Quarkus Helm
+
+**Note**: The `<chart name>` is set from either the property `quarkus.helm.name` or the `@HelmChart` annotation or the Quarkus application.
+
+# Requirements
+
+- Have installed [the Helm command line](https://helm.sh/docs/intro/install/)
+- Have connected/logged to a kubernetes cluster
+- Configure your Quarkus application to use any of the Quarkus Kubernetes extensions like Quarkus Kubernetes, Quarkus OpenShift or Quarkus Knative.
+- Configure your Quarkus application to use any of [the Quarkus Container Image extensions](https://quarkus.io/guides/container-image) - This example uses `container-image-docker`.
+
+# How can it be used?
+
+You can run the following Maven command in order to generate the Helm artifacts and build/push the image into a container registry:
+
+```shell
+mvn clean package -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=<your container registry> -Dquarkus.container-image.group=<your container registry namespace>
+```
+
+This command will push the image to a container registry and will become available when a pod or container is created.
+
+Finally, let's use Helm to deploy it into the cluster:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name>
+```
+
+The above command will deploy a chart using the default values (as defined within the `values.yaml` file). We can override the default values to use your `values.dev.yaml` file by executing the following command:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name> --values ./target/helm/<chart name>/kubernetes/values.dev.yaml
+```
+
+How can I update my deployment?
+
+- Via the `upgrade` option of Helm command line:
+
+After making changes to your project and regenerating the Helm resources and the application container image, then you need to upgrade your deployment:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name>
+```
+
+- Via the `set` option of Helm command line:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name> --set <app name>.replicas=1
+```
+
+How can we delete my deployment?
+
+```shell
+helm uninstall helm-example
+```

--- a/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/charts/rest-villains-java11-latest-kubernetes/templates/configmap.yaml
+++ b/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/charts/rest-villains-java11-latest-kubernetes/templates/configmap.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+  name: rest-villains-config
+data:
+  quarkus.hibernate-orm.database.generation: validate
+  quarkus.hibernate-orm.sql-load-script: no-file
+  quarkus.datasource.jdbc.url: jdbc:otel:postgresql://villains-db:5432/villains_database
+  quarkus.opentelemetry.tracer.exporter.otlp.endpoint: http://otel-collector:4317
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+  name: villains-db-init
+data:
+  get-data.sh: |-
+    #!/bin/bash
+
+    curl https://raw.githubusercontent.com/quarkusio/quarkus-super-heroes/main/rest-villains/deploy/db-init/initialize-tables.sql --output /docker-entrypoint-initdb.d/1-init-tables.sql

--- a/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/charts/rest-villains-java11-latest-kubernetes/templates/deployment.yaml
+++ b/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/charts/rest-villains-java11-latest-kubernetes/templates/deployment.yaml
@@ -1,0 +1,152 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    app.openshift.io/connects-to: "villains-db,otel-collector"
+    app.quarkus.io/vcs-ref: main
+    app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:43:10 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8084"
+    prometheus.io/scheme: http
+  labels:
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/version: java11-latest
+    app.kubernetes.io/part-of: villains-service
+    app.kubernetes.io/name: rest-villains
+  name: rest-villains
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/version: java11-latest
+      app.kubernetes.io/part-of: villains-service
+      app.kubernetes.io/name: rest-villains
+  template:
+    metadata:
+      annotations:
+        app.openshift.io/connects-to: "villains-db,otel-collector"
+        app.quarkus.io/vcs-ref: main
+        app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+        app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+        app.quarkus.io/build-timestamp: 2023-02-20 - 20:43:10 +0000
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /q/metrics
+        prometheus.io/port: "8084"
+        prometheus.io/scheme: http
+      labels:
+        app: rest-villains
+        application: villains-service
+        system: quarkus-super-heroes
+        app.kubernetes.io/version: java11-latest
+        app.kubernetes.io/part-of: villains-service
+        app.kubernetes.io/name: rest-villains
+    spec:
+      containers:
+        - env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom:
+            - configMapRef:
+                name: rest-villains-config
+            - secretRef:
+                name: rest-villains-config-creds
+          image: {{ .Values.app.image }}
+          imagePullPolicy: Always
+          livenessProbe:
+            failureThreshold: {{ .Values.app.livenessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.livenessProbe.httpGet.path }}
+              port: {{ .Values.app.livenessProbe.httpGet.port }}
+              scheme: {{ .Values.app.livenessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.livenessProbe.timeoutSeconds }}
+          name: rest-villains
+          ports:
+            - containerPort: 8084
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: {{ .Values.app.readinessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.readinessProbe.httpGet.path }}
+              port: {{ .Values.app.readinessProbe.httpGet.port }}
+              scheme: {{ .Values.app.readinessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.readinessProbe.timeoutSeconds }}
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 256Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: villains-service
+    app.openshift.io/runtime: postgresql
+  name: villains-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: villains-db
+  template:
+    metadata:
+      labels:
+        application: villains-service
+        name: villains-db
+    spec:
+      containers:
+        - envFrom:
+            - secretRef:
+                name: villains-db-config
+          image: bitnami/postgresql:14
+          name: villains-db
+          ports:
+            - containerPort: 5432
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              memory: 32Mi
+          volumeMounts:
+            - mountPath: /bitnami/postgresql
+              name: villains-db-data
+            - mountPath: /docker-entrypoint-initdb.d
+              name: villains-db-init-data
+      initContainers:
+        - command:
+            - sh
+            - get-data.sh
+          image: registry.access.redhat.com/ubi8-minimal:8.6
+          name: get-data
+          volumeMounts:
+            - mountPath: /docker-entrypoint-preinitdb.d
+              name: villains-db-init
+            - mountPath: /docker-entrypoint-initdb.d
+              name: villains-db-init-data
+          workingDir: /docker-entrypoint-preinitdb.d
+      volumes:
+        - emptyDir: {}
+          name: villains-db-data
+        - emptyDir: {}
+          name: villains-db-init-data
+        - configMap:
+            name: villains-db-init
+          name: villains-db-init

--- a/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/charts/rest-villains-java11-latest-kubernetes/templates/secret.yaml
+++ b/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/charts/rest-villains-java11-latest-kubernetes/templates/secret.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+  name: rest-villains-config-creds
+data:
+  quarkus.datasource.username: c3VwZXJiYWQ=
+  quarkus.datasource.password: c3VwZXJiYWQ=
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+  name: villains-db-config
+data:
+  POSTGRESQL_DATABASE: dmlsbGFpbnNfZGF0YWJhc2U=
+  POSTGRESQL_USERNAME: c3VwZXJiYWQ=
+  POSTGRESQL_PASSWORD: c3VwZXJiYWQ=
+type: Opaque

--- a/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/charts/rest-villains-java11-latest-kubernetes/templates/service.yaml
+++ b/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/charts/rest-villains-java11-latest-kubernetes/templates/service.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+  name: villains-db
+spec:
+  ports:
+    - port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    name: villains-db
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    app.openshift.io/connects-to: "villains-db,otel-collector"
+    app.quarkus.io/vcs-ref: main
+    app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:43:10 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8084"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: rest-villains
+    app.kubernetes.io/part-of: villains-service
+    app.kubernetes.io/version: java11-latest
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+  name: rest-villains
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8084
+  selector:
+    app.kubernetes.io/name: rest-villains
+    app.kubernetes.io/part-of: villains-service
+    app.kubernetes.io/version: java11-latest
+  type: {{ .Values.app.serviceType }}

--- a/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/charts/rest-villains-java11-latest-kubernetes/values.yaml
+++ b/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/charts/rest-villains-java11-latest-kubernetes/values.yaml
@@ -1,0 +1,24 @@
+---
+app:
+  serviceType: ClusterIP
+  livenessProbe:
+    failureThreshold: 3
+    periodSeconds: 10
+    timeoutSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/live
+      scheme: HTTP
+      port: 8084
+  image: quay.io/quarkus-super-heroes/rest-villains:java11-latest
+  readinessProbe:
+    failureThreshold: 3
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/ready
+      scheme: HTTP
+      port: 8084

--- a/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/templates/NOTES.txt
+++ b/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/templates/NOTES.txt
@@ -1,0 +1,72 @@
+# Quarkus Helm Notes
+
+To access the Helm annotations or properties you just need to have the following dependency in your
+class path:
+
+    <dependency>
+        <groupId>io.quarkiverse.helm</groupId>
+        <artifactId>quarkus-helm</artifactId>
+        <version>{quarkus-helm-version}</version>
+    </dependency>
+
+Build the project using:
+
+    mvn clean package
+
+You can find the generated Helm artifacts under: `target/helm/kubernetes/<chart name>/` that should look like:
+- Chart.yaml
+- values.yaml
+- templates/*.yml the generated resources by Quarkus Helm
+
+**Note**: The `<chart name>` is set from either the property `quarkus.helm.name` or the `@HelmChart` annotation or the Quarkus application.
+
+# Requirements
+
+- Have installed [the Helm command line](https://helm.sh/docs/intro/install/)
+- Have connected/logged to a kubernetes cluster
+- Configure your Quarkus application to use any of the Quarkus Kubernetes extensions like Quarkus Kubernetes, Quarkus OpenShift or Quarkus Knative.
+- Configure your Quarkus application to use any of [the Quarkus Container Image extensions](https://quarkus.io/guides/container-image) - This example uses `container-image-docker`.
+
+# How can it be used?
+
+You can run the following Maven command in order to generate the Helm artifacts and build/push the image into a container registry:
+
+```shell
+mvn clean package -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=<your container registry> -Dquarkus.container-image.group=<your container registry namespace>
+```
+
+This command will push the image to a container registry and will become available when a pod or container is created.
+
+Finally, let's use Helm to deploy it into the cluster:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name>
+```
+
+The above command will deploy a chart using the default values (as defined within the `values.yaml` file). We can override the default values to use your `values.dev.yaml` file by executing the following command:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name> --values ./target/helm/<chart name>/kubernetes/values.dev.yaml
+```
+
+How can I update my deployment?
+
+- Via the `upgrade` option of Helm command line:
+
+After making changes to your project and regenerating the Helm resources and the application container image, then you need to upgrade your deployment:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name>
+```
+
+- Via the `set` option of Helm command line:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name> --set <app name>.replicas=1
+```
+
+How can we delete my deployment?
+
+```shell
+helm uninstall helm-example
+```

--- a/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/templates/configmap.yaml
+++ b/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/templates/configmap.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: rest-fights
+    application: fights-service
+    system: quarkus-super-heroes
+  name: rest-fights-config
+data:
+  quarkus.liquibase-mongodb.migrate-at-start: "false"
+  quarkus.mongodb.hosts: fights-db:27017
+  quarkus.stork.hero-service.service-discovery.type: kubernetes
+  quarkus.stork.hero-service.service-discovery.application: rest-heroes
+  quarkus.stork.hero-service.service-discovery.refresh-period: 1M
+  quarkus.stork.villain-service.service-discovery.type: kubernetes
+  quarkus.stork.villain-service.service-discovery.application: rest-villains
+  quarkus.stork.villain-service.service-discovery.refresh-period: 1M
+  quarkus.opentelemetry.tracer.exporter.otlp.endpoint: http://otel-collector:4317
+  kafka.bootstrap.servers: PLAINTEXT://fights-kafka:9092
+  mp.messaging.connector.smallrye-kafka.apicurio.registry.url: http://apicurio:8080/apis/registry/v2

--- a/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/templates/deployment.yaml
+++ b/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/templates/deployment.yaml
@@ -1,0 +1,240 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    app.openshift.io/connects-to: "fights-db,fights-kafka,apicurio,rest-villains,rest-heroes,otel-collector"
+    app.quarkus.io/vcs-ref: main
+    app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:44:33 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8082"
+    prometheus.io/scheme: http
+  labels:
+    app: rest-fights
+    application: fights-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: fights-service
+    app.kubernetes.io/name: rest-fights
+    app.kubernetes.io/version: java11-latest
+  name: rest-fights
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/part-of: fights-service
+      app.kubernetes.io/name: rest-fights
+      app.kubernetes.io/version: java11-latest
+  template:
+    metadata:
+      annotations:
+        app.openshift.io/connects-to: "fights-db,fights-kafka,apicurio,rest-villains,rest-heroes,otel-collector"
+        app.quarkus.io/vcs-ref: main
+        app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+        app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+        app.quarkus.io/build-timestamp: 2023-02-20 - 20:44:33 +0000
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /q/metrics
+        prometheus.io/port: "8082"
+        prometheus.io/scheme: http
+      labels:
+        app: rest-fights
+        application: fights-service
+        system: quarkus-super-heroes
+        app.kubernetes.io/part-of: fights-service
+        app.kubernetes.io/name: rest-fights
+        app.kubernetes.io/version: java11-latest
+    spec:
+      containers:
+        - env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom:
+            - configMapRef:
+                name: rest-fights-config
+            - secretRef:
+                name: rest-fights-config-creds
+          image: {{ .Values.app.image }}
+          imagePullPolicy: Always
+          livenessProbe:
+            failureThreshold: {{ .Values.app.livenessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.livenessProbe.httpGet.path }}
+              port: {{ .Values.app.livenessProbe.httpGet.port }}
+              scheme: {{ .Values.app.livenessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.livenessProbe.timeoutSeconds }}
+          name: rest-fights
+          ports:
+            - containerPort: 8082
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: {{ .Values.app.readinessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.readinessProbe.httpGet.path }}
+              port: {{ .Values.app.readinessProbe.httpGet.port }}
+              scheme: {{ .Values.app.readinessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.readinessProbe.timeoutSeconds }}
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 256Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: fights-db
+    application: fights-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: fights-service
+    app.openshift.io/runtime: mongodb
+  name: fights-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: fights-db
+  template:
+    metadata:
+      labels:
+        application: fights-service
+        name: fights-db
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - envFrom:
+            - secretRef:
+                name: fights-db-config
+          image: bitnami/mongodb:5.0
+          name: fights-db
+          ports:
+            - containerPort: 27017
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              memory: 64Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: fights-kafka
+    application: fights-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: fights-service
+    app.openshift.io/runtime: amq
+  name: fights-kafka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: fights-kafka
+  template:
+    metadata:
+      labels:
+        application: fights-service
+        name: fights-kafka
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - command:
+            - sh
+            - -c
+            - "export CLUSTER_ID=$(bin/kafka-storage.sh random-uuid) && bin/kafka-storage.sh format -t ${CLUSTER_ID} -c config/kraft/server.properties && bin/kafka-server-start.sh config/kraft/server.properties --override advertised.listeners=${KAFKA_ADVERTISED_LISTENERS}"
+          env:
+            - name: LOG_DIR
+              value: /tmp/logs
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: PLAINTEXT://fights-kafka:9092
+          image: quay.io/strimzi/kafka:0.28.0-kafka-3.1.0
+          name: fights-kafka
+          ports:
+            - containerPort: 9092
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 128Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
+  labels:
+    app: apicurio
+    application: fights-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: fights-service
+    app.kubernetes.io/name: apicurio
+    app.kubernetes.io/version: 2.2.3.Final
+    app.openshift.io/runtime: apicurio
+  name: apicurio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: apicurio
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scheme: http
+      labels:
+        application: fights-service
+        name: apicurio
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - env:
+            - name: REGISTRY_AUTH_ANONYMOUS_READ_ACCESS_ENABLED
+              value: "true"
+          image: quay.io/apicurio/apicurio-registry-mem:2.2.3.Final
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health/live
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          name: apicurio
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health/ready
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 128Mi

--- a/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/templates/rolebinding.yaml
+++ b/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/templates/rolebinding.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: default_view
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: default

--- a/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/templates/secret.yaml
+++ b/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/templates/secret.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: rest-fights
+    application: fights-service
+    system: quarkus-super-heroes
+  name: rest-fights-config-creds
+data:
+  quarkus.mongodb.credentials.username: c3VwZXJmaWdodA==
+  quarkus.mongodb.credentials.password: c3VwZXJmaWdodA==
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: fights-db
+    application: fights-service
+    system: quarkus-super-heroes
+  name: fights-db-config
+data:
+  MONGODB_DATABASE: ZmlnaHRz
+  MONGODB_USERNAME: c3VwZXJmaWdodA==
+  MONGODB_PASSWORD: c3VwZXJmaWdodA==
+  MONGODB_ROOT_USER: c3VwZXI=
+  MONGODB_ROOT_PASSWORD: c3VwZXI=
+type: Opaque

--- a/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/templates/service.yaml
+++ b/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/templates/service.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: fights-db
+    application: fights-service
+    system: quarkus-super-heroes
+  name: fights-db
+spec:
+  ports:
+    - port: 27017
+      protocol: TCP
+      targetPort: 27017
+  selector:
+    name: fights-db
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: fights-kafka
+    application: fights-service
+    system: quarkus-super-heroes
+  name: fights-kafka
+spec:
+  ports:
+    - port: 9092
+      protocol: TCP
+      targetPort: 9092
+  selector:
+    name: fights-kafka
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
+  labels:
+    name: apicurio
+    application: fights-service
+    system: quarkus-super-heroes
+  name: apicurio
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    name: apicurio
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    app.openshift.io/connects-to: "fights-db,fights-kafka,apicurio,rest-villains,rest-heroes,otel-collector"
+    app.quarkus.io/vcs-ref: main
+    app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:44:33 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8082"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: rest-fights
+    app.kubernetes.io/part-of: fights-service
+    app.kubernetes.io/version: java11-latest
+    app: rest-fights
+    application: fights-service
+    system: quarkus-super-heroes
+  name: rest-fights
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8082
+  selector:
+    app.kubernetes.io/name: rest-fights
+    app.kubernetes.io/part-of: fights-service
+    app.kubernetes.io/version: java11-latest
+  type: {{ .Values.app.serviceType }}

--- a/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/values.yaml
+++ b/rest-fights/deploy/helm/kubernetes/rest-fights-java11-latest-kubernetes/values.yaml
@@ -1,0 +1,24 @@
+---
+app:
+  serviceType: ClusterIP
+  livenessProbe:
+    failureThreshold: 3
+    periodSeconds: 10
+    timeoutSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/live
+      scheme: HTTP
+      port: 8082
+  image: quay.io/quarkus-super-heroes/rest-fights:java11-latest
+  readinessProbe:
+    failureThreshold: 3
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/ready
+      scheme: HTTP
+      port: 8082

--- a/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/Chart.yaml
+++ b/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/Chart.yaml
@@ -1,0 +1,4 @@
+---
+name: rest-fights-java11-latest-minikube
+version: 1.0.0
+apiVersion: v2

--- a/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/charts/rest-heroes-java11-latest-minikube/Chart.yaml
+++ b/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/charts/rest-heroes-java11-latest-minikube/Chart.yaml
@@ -1,0 +1,4 @@
+---
+name: rest-heroes-java11-latest-minikube
+version: 1.0.0
+apiVersion: v2

--- a/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/charts/rest-heroes-java11-latest-minikube/templates/NOTES.txt
+++ b/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/charts/rest-heroes-java11-latest-minikube/templates/NOTES.txt
@@ -1,0 +1,72 @@
+# Quarkus Helm Notes
+
+To access the Helm annotations or properties you just need to have the following dependency in your
+class path:
+
+    <dependency>
+        <groupId>io.quarkiverse.helm</groupId>
+        <artifactId>quarkus-helm</artifactId>
+        <version>{quarkus-helm-version}</version>
+    </dependency>
+
+Build the project using:
+
+    mvn clean package
+
+You can find the generated Helm artifacts under: `target/helm/kubernetes/<chart name>/` that should look like:
+- Chart.yaml
+- values.yaml
+- templates/*.yml the generated resources by Quarkus Helm
+
+**Note**: The `<chart name>` is set from either the property `quarkus.helm.name` or the `@HelmChart` annotation or the Quarkus application.
+
+# Requirements
+
+- Have installed [the Helm command line](https://helm.sh/docs/intro/install/)
+- Have connected/logged to a kubernetes cluster
+- Configure your Quarkus application to use any of the Quarkus Kubernetes extensions like Quarkus Kubernetes, Quarkus OpenShift or Quarkus Knative.
+- Configure your Quarkus application to use any of [the Quarkus Container Image extensions](https://quarkus.io/guides/container-image) - This example uses `container-image-docker`.
+
+# How can it be used?
+
+You can run the following Maven command in order to generate the Helm artifacts and build/push the image into a container registry:
+
+```shell
+mvn clean package -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=<your container registry> -Dquarkus.container-image.group=<your container registry namespace>
+```
+
+This command will push the image to a container registry and will become available when a pod or container is created.
+
+Finally, let's use Helm to deploy it into the cluster:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name>
+```
+
+The above command will deploy a chart using the default values (as defined within the `values.yaml` file). We can override the default values to use your `values.dev.yaml` file by executing the following command:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name> --values ./target/helm/<chart name>/kubernetes/values.dev.yaml
+```
+
+How can I update my deployment?
+
+- Via the `upgrade` option of Helm command line:
+
+After making changes to your project and regenerating the Helm resources and the application container image, then you need to upgrade your deployment:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name>
+```
+
+- Via the `set` option of Helm command line:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name> --set <app name>.replicas=1
+```
+
+How can we delete my deployment?
+
+```shell
+helm uninstall helm-example
+```

--- a/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/charts/rest-heroes-java11-latest-minikube/templates/configmap.yaml
+++ b/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/charts/rest-heroes-java11-latest-minikube/templates/configmap.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: rest-heroes-config
+data:
+  quarkus.hibernate-orm.database.generation: validate
+  quarkus.hibernate-orm.sql-load-script: no-file
+  quarkus.datasource.reactive.url: postgresql://heroes-db:5432/heroes_database
+  quarkus.opentelemetry.tracer.exporter.otlp.endpoint: http://otel-collector:4317
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: heroes-db-init
+data:
+  get-data.sh: |-
+    #!/bin/bash
+
+    curl https://raw.githubusercontent.com/quarkusio/quarkus-super-heroes/main/rest-heroes/deploy/db-init/initialize-tables.sql --output /docker-entrypoint-initdb.d/1-init-tables.sql

--- a/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/charts/rest-heroes-java11-latest-minikube/templates/deployment.yaml
+++ b/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/charts/rest-heroes-java11-latest-minikube/templates/deployment.yaml
@@ -1,0 +1,153 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    app.quarkus.io/vcs-ref: main
+    app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "heroes-db,otel-collector"
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:46:26 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8083"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: rest-heroes
+    app.kubernetes.io/part-of: heroes-service
+    app.kubernetes.io/version: java11-latest
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: rest-heroes
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: rest-heroes
+      app.kubernetes.io/part-of: heroes-service
+      app.kubernetes.io/version: java11-latest
+  template:
+    metadata:
+      annotations:
+        app.quarkus.io/vcs-ref: main
+        app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+        app.openshift.io/connects-to: "heroes-db,otel-collector"
+        app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+        app.quarkus.io/build-timestamp: 2023-02-20 - 20:46:26 +0000
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /q/metrics
+        prometheus.io/port: "8083"
+        prometheus.io/scheme: http
+      labels:
+        app.kubernetes.io/name: rest-heroes
+        app.kubernetes.io/part-of: heroes-service
+        app.kubernetes.io/version: java11-latest
+        app: rest-heroes
+        application: heroes-service
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom:
+            - configMapRef:
+                name: rest-heroes-config
+            - secretRef:
+                name: rest-heroes-config-creds
+          image: {{ .Values.app.image }}
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: {{ .Values.app.livenessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.livenessProbe.httpGet.path }}
+              port: {{ .Values.app.livenessProbe.httpGet.port }}
+              scheme: {{ .Values.app.livenessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.livenessProbe.timeoutSeconds }}
+          name: rest-heroes
+          ports:
+            - containerPort: 8083
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: {{ .Values.app.readinessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.readinessProbe.httpGet.path }}
+              port: {{ .Values.app.readinessProbe.httpGet.port }}
+              scheme: {{ .Values.app.readinessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.readinessProbe.timeoutSeconds }}
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 256Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: heroes-service
+    app.openshift.io/runtime: postgresql
+  name: heroes-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: heroes-db
+  template:
+    metadata:
+      labels:
+        name: heroes-db
+        application: heroes-service
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - envFrom:
+            - secretRef:
+                name: heroes-db-config
+          image: bitnami/postgresql:14
+          name: heroes-db
+          ports:
+            - containerPort: 5432
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              memory: 32Mi
+          volumeMounts:
+            - mountPath: /bitnami/postgresql
+              name: heroes-db-data
+            - mountPath: /docker-entrypoint-initdb.d
+              name: heroes-db-init-data
+      initContainers:
+        - command:
+            - sh
+            - get-data.sh
+          image: registry.access.redhat.com/ubi8-minimal:8.6
+          name: get-data
+          volumeMounts:
+            - mountPath: /docker-entrypoint-preinitdb.d
+              name: heroes-db-init
+            - mountPath: /docker-entrypoint-initdb.d
+              name: heroes-db-init-data
+          workingDir: /docker-entrypoint-preinitdb.d
+      volumes:
+        - emptyDir: {}
+          name: heroes-db-data
+        - emptyDir: {}
+          name: heroes-db-init-data
+        - configMap:
+            name: heroes-db-init
+          name: heroes-db-init

--- a/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/charts/rest-heroes-java11-latest-minikube/templates/secret.yaml
+++ b/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/charts/rest-heroes-java11-latest-minikube/templates/secret.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: rest-heroes-config-creds
+data:
+  quarkus.datasource.username: c3VwZXJtYW4=
+  quarkus.datasource.password: c3VwZXJtYW4=
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: heroes-db-config
+data:
+  POSTGRESQL_DATABASE: aGVyb2VzX2RhdGFiYXNl
+  POSTGRESQL_USERNAME: c3VwZXJtYW4=
+  POSTGRESQL_PASSWORD: c3VwZXJtYW4=
+type: Opaque

--- a/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/charts/rest-heroes-java11-latest-minikube/templates/service.yaml
+++ b/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/charts/rest-heroes-java11-latest-minikube/templates/service.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: heroes-db
+spec:
+  ports:
+    - port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    name: heroes-db
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    app.quarkus.io/vcs-ref: main
+    app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "heroes-db,otel-collector"
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:46:26 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8083"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: rest-heroes
+    app.kubernetes.io/part-of: heroes-service
+    app.kubernetes.io/version: java11-latest
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: rest-heroes
+spec:
+  ports:
+    - name: http
+      nodePort: 30471
+      port: 80
+      protocol: TCP
+      targetPort: 8083
+  selector:
+    app.kubernetes.io/name: rest-heroes
+    app.kubernetes.io/part-of: heroes-service
+    app.kubernetes.io/version: java11-latest
+  type: {{ .Values.app.serviceType }}

--- a/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/charts/rest-heroes-java11-latest-minikube/values.yaml
+++ b/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/charts/rest-heroes-java11-latest-minikube/values.yaml
@@ -1,0 +1,24 @@
+---
+app:
+  serviceType: ClusterIP
+  livenessProbe:
+    failureThreshold: 3
+    periodSeconds: 10
+    timeoutSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/live
+      scheme: HTTP
+      port: 8083
+  image: quay.io/quarkus-super-heroes/rest-heroes:java11-latest
+  readinessProbe:
+    failureThreshold: 3
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/ready
+      scheme: HTTP
+      port: 8083

--- a/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/charts/rest-villains-java11-latest-minikube/Chart.yaml
+++ b/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/charts/rest-villains-java11-latest-minikube/Chart.yaml
@@ -1,0 +1,4 @@
+---
+name: rest-villains-java11-latest-minikube
+version: 1.0.0
+apiVersion: v2

--- a/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/charts/rest-villains-java11-latest-minikube/templates/NOTES.txt
+++ b/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/charts/rest-villains-java11-latest-minikube/templates/NOTES.txt
@@ -1,0 +1,72 @@
+# Quarkus Helm Notes
+
+To access the Helm annotations or properties you just need to have the following dependency in your
+class path:
+
+    <dependency>
+        <groupId>io.quarkiverse.helm</groupId>
+        <artifactId>quarkus-helm</artifactId>
+        <version>{quarkus-helm-version}</version>
+    </dependency>
+
+Build the project using:
+
+    mvn clean package
+
+You can find the generated Helm artifacts under: `target/helm/kubernetes/<chart name>/` that should look like:
+- Chart.yaml
+- values.yaml
+- templates/*.yml the generated resources by Quarkus Helm
+
+**Note**: The `<chart name>` is set from either the property `quarkus.helm.name` or the `@HelmChart` annotation or the Quarkus application.
+
+# Requirements
+
+- Have installed [the Helm command line](https://helm.sh/docs/intro/install/)
+- Have connected/logged to a kubernetes cluster
+- Configure your Quarkus application to use any of the Quarkus Kubernetes extensions like Quarkus Kubernetes, Quarkus OpenShift or Quarkus Knative.
+- Configure your Quarkus application to use any of [the Quarkus Container Image extensions](https://quarkus.io/guides/container-image) - This example uses `container-image-docker`.
+
+# How can it be used?
+
+You can run the following Maven command in order to generate the Helm artifacts and build/push the image into a container registry:
+
+```shell
+mvn clean package -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=<your container registry> -Dquarkus.container-image.group=<your container registry namespace>
+```
+
+This command will push the image to a container registry and will become available when a pod or container is created.
+
+Finally, let's use Helm to deploy it into the cluster:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name>
+```
+
+The above command will deploy a chart using the default values (as defined within the `values.yaml` file). We can override the default values to use your `values.dev.yaml` file by executing the following command:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name> --values ./target/helm/<chart name>/kubernetes/values.dev.yaml
+```
+
+How can I update my deployment?
+
+- Via the `upgrade` option of Helm command line:
+
+After making changes to your project and regenerating the Helm resources and the application container image, then you need to upgrade your deployment:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name>
+```
+
+- Via the `set` option of Helm command line:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name> --set <app name>.replicas=1
+```
+
+How can we delete my deployment?
+
+```shell
+helm uninstall helm-example
+```

--- a/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/charts/rest-villains-java11-latest-minikube/templates/configmap.yaml
+++ b/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/charts/rest-villains-java11-latest-minikube/templates/configmap.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+  name: rest-villains-config
+data:
+  quarkus.hibernate-orm.database.generation: validate
+  quarkus.hibernate-orm.sql-load-script: no-file
+  quarkus.datasource.jdbc.url: jdbc:otel:postgresql://villains-db:5432/villains_database
+  quarkus.opentelemetry.tracer.exporter.otlp.endpoint: http://otel-collector:4317
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+  name: villains-db-init
+data:
+  get-data.sh: |-
+    #!/bin/bash
+
+    curl https://raw.githubusercontent.com/quarkusio/quarkus-super-heroes/main/rest-villains/deploy/db-init/initialize-tables.sql --output /docker-entrypoint-initdb.d/1-init-tables.sql

--- a/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/charts/rest-villains-java11-latest-minikube/templates/deployment.yaml
+++ b/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/charts/rest-villains-java11-latest-minikube/templates/deployment.yaml
@@ -1,0 +1,152 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    app.quarkus.io/vcs-ref: main
+    app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "villains-db,otel-collector"
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:45:53 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8084"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: rest-villains
+    app.kubernetes.io/part-of: villains-service
+    app.kubernetes.io/version: java11-latest
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+  name: rest-villains
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: rest-villains
+      app.kubernetes.io/part-of: villains-service
+      app.kubernetes.io/version: java11-latest
+  template:
+    metadata:
+      annotations:
+        app.quarkus.io/vcs-ref: main
+        app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+        app.openshift.io/connects-to: "villains-db,otel-collector"
+        app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+        app.quarkus.io/build-timestamp: 2023-02-20 - 20:45:53 +0000
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /q/metrics
+        prometheus.io/port: "8084"
+        prometheus.io/scheme: http
+      labels:
+        app.kubernetes.io/name: rest-villains
+        app.kubernetes.io/part-of: villains-service
+        app.kubernetes.io/version: java11-latest
+        app: rest-villains
+        application: villains-service
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom:
+            - configMapRef:
+                name: rest-villains-config
+            - secretRef:
+                name: rest-villains-config-creds
+          image: {{ .Values.app.image }}
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: {{ .Values.app.livenessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.livenessProbe.httpGet.path }}
+              port: {{ .Values.app.livenessProbe.httpGet.port }}
+              scheme: {{ .Values.app.livenessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.livenessProbe.timeoutSeconds }}
+          name: rest-villains
+          ports:
+            - containerPort: 8084
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: {{ .Values.app.readinessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.readinessProbe.httpGet.path }}
+              port: {{ .Values.app.readinessProbe.httpGet.port }}
+              scheme: {{ .Values.app.readinessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.readinessProbe.timeoutSeconds }}
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 256Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: villains-service
+    app.openshift.io/runtime: postgresql
+  name: villains-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: villains-db
+  template:
+    metadata:
+      labels:
+        application: villains-service
+        name: villains-db
+    spec:
+      containers:
+        - envFrom:
+            - secretRef:
+                name: villains-db-config
+          image: bitnami/postgresql:14
+          name: villains-db
+          ports:
+            - containerPort: 5432
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              memory: 32Mi
+          volumeMounts:
+            - mountPath: /bitnami/postgresql
+              name: villains-db-data
+            - mountPath: /docker-entrypoint-initdb.d
+              name: villains-db-init-data
+      initContainers:
+        - command:
+            - sh
+            - get-data.sh
+          image: registry.access.redhat.com/ubi8-minimal:8.6
+          name: get-data
+          volumeMounts:
+            - mountPath: /docker-entrypoint-preinitdb.d
+              name: villains-db-init
+            - mountPath: /docker-entrypoint-initdb.d
+              name: villains-db-init-data
+          workingDir: /docker-entrypoint-preinitdb.d
+      volumes:
+        - emptyDir: {}
+          name: villains-db-data
+        - emptyDir: {}
+          name: villains-db-init-data
+        - configMap:
+            name: villains-db-init
+          name: villains-db-init

--- a/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/charts/rest-villains-java11-latest-minikube/templates/secret.yaml
+++ b/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/charts/rest-villains-java11-latest-minikube/templates/secret.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+  name: rest-villains-config-creds
+data:
+  quarkus.datasource.username: c3VwZXJiYWQ=
+  quarkus.datasource.password: c3VwZXJiYWQ=
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+  name: villains-db-config
+data:
+  POSTGRESQL_DATABASE: dmlsbGFpbnNfZGF0YWJhc2U=
+  POSTGRESQL_USERNAME: c3VwZXJiYWQ=
+  POSTGRESQL_PASSWORD: c3VwZXJiYWQ=
+type: Opaque

--- a/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/charts/rest-villains-java11-latest-minikube/templates/service.yaml
+++ b/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/charts/rest-villains-java11-latest-minikube/templates/service.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+  name: villains-db
+spec:
+  ports:
+    - port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    name: villains-db
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    app.quarkus.io/vcs-ref: main
+    app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "villains-db,otel-collector"
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:45:53 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8084"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: rest-villains
+    app.kubernetes.io/part-of: villains-service
+    app.kubernetes.io/version: java11-latest
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+  name: rest-villains
+spec:
+  ports:
+    - name: http
+      nodePort: 30526
+      port: 80
+      protocol: TCP
+      targetPort: 8084
+  selector:
+    app.kubernetes.io/name: rest-villains
+    app.kubernetes.io/part-of: villains-service
+    app.kubernetes.io/version: java11-latest
+  type: {{ .Values.app.serviceType }}

--- a/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/charts/rest-villains-java11-latest-minikube/values.yaml
+++ b/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/charts/rest-villains-java11-latest-minikube/values.yaml
@@ -1,0 +1,24 @@
+---
+app:
+  serviceType: ClusterIP
+  livenessProbe:
+    failureThreshold: 3
+    periodSeconds: 10
+    timeoutSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/live
+      scheme: HTTP
+      port: 8084
+  image: rest-villains:java11-latest
+  readinessProbe:
+    failureThreshold: 3
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/ready
+      scheme: HTTP
+      port: 8084

--- a/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/templates/NOTES.txt
+++ b/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/templates/NOTES.txt
@@ -1,0 +1,72 @@
+# Quarkus Helm Notes
+
+To access the Helm annotations or properties you just need to have the following dependency in your
+class path:
+
+    <dependency>
+        <groupId>io.quarkiverse.helm</groupId>
+        <artifactId>quarkus-helm</artifactId>
+        <version>{quarkus-helm-version}</version>
+    </dependency>
+
+Build the project using:
+
+    mvn clean package
+
+You can find the generated Helm artifacts under: `target/helm/kubernetes/<chart name>/` that should look like:
+- Chart.yaml
+- values.yaml
+- templates/*.yml the generated resources by Quarkus Helm
+
+**Note**: The `<chart name>` is set from either the property `quarkus.helm.name` or the `@HelmChart` annotation or the Quarkus application.
+
+# Requirements
+
+- Have installed [the Helm command line](https://helm.sh/docs/intro/install/)
+- Have connected/logged to a kubernetes cluster
+- Configure your Quarkus application to use any of the Quarkus Kubernetes extensions like Quarkus Kubernetes, Quarkus OpenShift or Quarkus Knative.
+- Configure your Quarkus application to use any of [the Quarkus Container Image extensions](https://quarkus.io/guides/container-image) - This example uses `container-image-docker`.
+
+# How can it be used?
+
+You can run the following Maven command in order to generate the Helm artifacts and build/push the image into a container registry:
+
+```shell
+mvn clean package -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=<your container registry> -Dquarkus.container-image.group=<your container registry namespace>
+```
+
+This command will push the image to a container registry and will become available when a pod or container is created.
+
+Finally, let's use Helm to deploy it into the cluster:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name>
+```
+
+The above command will deploy a chart using the default values (as defined within the `values.yaml` file). We can override the default values to use your `values.dev.yaml` file by executing the following command:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name> --values ./target/helm/<chart name>/kubernetes/values.dev.yaml
+```
+
+How can I update my deployment?
+
+- Via the `upgrade` option of Helm command line:
+
+After making changes to your project and regenerating the Helm resources and the application container image, then you need to upgrade your deployment:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name>
+```
+
+- Via the `set` option of Helm command line:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name> --set <app name>.replicas=1
+```
+
+How can we delete my deployment?
+
+```shell
+helm uninstall helm-example
+```

--- a/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/templates/configmap.yaml
+++ b/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/templates/configmap.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: rest-fights
+    application: fights-service
+    system: quarkus-super-heroes
+  name: rest-fights-config
+data:
+  quarkus.liquibase-mongodb.migrate-at-start: "false"
+  quarkus.mongodb.hosts: fights-db:27017
+  quarkus.stork.hero-service.service-discovery.type: kubernetes
+  quarkus.stork.hero-service.service-discovery.application: rest-heroes
+  quarkus.stork.hero-service.service-discovery.refresh-period: 1M
+  quarkus.stork.villain-service.service-discovery.type: kubernetes
+  quarkus.stork.villain-service.service-discovery.application: rest-villains
+  quarkus.stork.villain-service.service-discovery.refresh-period: 1M
+  quarkus.opentelemetry.tracer.exporter.otlp.endpoint: http://otel-collector:4317
+  kafka.bootstrap.servers: PLAINTEXT://fights-kafka:9092
+  mp.messaging.connector.smallrye-kafka.apicurio.registry.url: http://apicurio:8080/apis/registry/v2

--- a/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/templates/deployment.yaml
+++ b/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/templates/deployment.yaml
@@ -1,0 +1,240 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    app.quarkus.io/vcs-ref: main
+    app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "fights-db,fights-kafka,apicurio,rest-villains,rest-heroes,otel-collector"
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:47:03 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8082"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: rest-fights
+    app.kubernetes.io/part-of: fights-service
+    app.kubernetes.io/version: java11-latest
+    app: rest-fights
+    application: fights-service
+    system: quarkus-super-heroes
+  name: rest-fights
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: rest-fights
+      app.kubernetes.io/part-of: fights-service
+      app.kubernetes.io/version: java11-latest
+  template:
+    metadata:
+      annotations:
+        app.quarkus.io/vcs-ref: main
+        app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+        app.openshift.io/connects-to: "fights-db,fights-kafka,apicurio,rest-villains,rest-heroes,otel-collector"
+        app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+        app.quarkus.io/build-timestamp: 2023-02-20 - 20:47:03 +0000
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /q/metrics
+        prometheus.io/port: "8082"
+        prometheus.io/scheme: http
+      labels:
+        app.kubernetes.io/name: rest-fights
+        app.kubernetes.io/part-of: fights-service
+        app.kubernetes.io/version: java11-latest
+        app: rest-fights
+        application: fights-service
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom:
+            - configMapRef:
+                name: rest-fights-config
+            - secretRef:
+                name: rest-fights-config-creds
+          image: {{ .Values.app.image }}
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: {{ .Values.app.livenessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.livenessProbe.httpGet.path }}
+              port: {{ .Values.app.livenessProbe.httpGet.port }}
+              scheme: {{ .Values.app.livenessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.livenessProbe.timeoutSeconds }}
+          name: rest-fights
+          ports:
+            - containerPort: 8082
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: {{ .Values.app.readinessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.readinessProbe.httpGet.path }}
+              port: {{ .Values.app.readinessProbe.httpGet.port }}
+              scheme: {{ .Values.app.readinessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.readinessProbe.timeoutSeconds }}
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 256Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: fights-db
+    application: fights-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: fights-service
+    app.openshift.io/runtime: mongodb
+  name: fights-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: fights-db
+  template:
+    metadata:
+      labels:
+        application: fights-service
+        name: fights-db
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - envFrom:
+            - secretRef:
+                name: fights-db-config
+          image: bitnami/mongodb:5.0
+          name: fights-db
+          ports:
+            - containerPort: 27017
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              memory: 64Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: fights-kafka
+    application: fights-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: fights-service
+    app.openshift.io/runtime: amq
+  name: fights-kafka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: fights-kafka
+  template:
+    metadata:
+      labels:
+        application: fights-service
+        name: fights-kafka
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - command:
+            - sh
+            - -c
+            - "export CLUSTER_ID=$(bin/kafka-storage.sh random-uuid) && bin/kafka-storage.sh format -t ${CLUSTER_ID} -c config/kraft/server.properties && bin/kafka-server-start.sh config/kraft/server.properties --override advertised.listeners=${KAFKA_ADVERTISED_LISTENERS}"
+          env:
+            - name: LOG_DIR
+              value: /tmp/logs
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: PLAINTEXT://fights-kafka:9092
+          image: quay.io/strimzi/kafka:0.28.0-kafka-3.1.0
+          name: fights-kafka
+          ports:
+            - containerPort: 9092
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 128Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
+  labels:
+    app: apicurio
+    application: fights-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: fights-service
+    app.kubernetes.io/name: apicurio
+    app.kubernetes.io/version: 2.2.3.Final
+    app.openshift.io/runtime: apicurio
+  name: apicurio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: apicurio
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scheme: http
+      labels:
+        application: fights-service
+        name: apicurio
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - env:
+            - name: REGISTRY_AUTH_ANONYMOUS_READ_ACCESS_ENABLED
+              value: "true"
+          image: quay.io/apicurio/apicurio-registry-mem:2.2.3.Final
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health/live
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          name: apicurio
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health/ready
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 128Mi

--- a/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/templates/rolebinding.yaml
+++ b/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/templates/rolebinding.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: default_view
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: default

--- a/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/templates/secret.yaml
+++ b/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/templates/secret.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: rest-fights
+    application: fights-service
+    system: quarkus-super-heroes
+  name: rest-fights-config-creds
+data:
+  quarkus.mongodb.credentials.username: c3VwZXJmaWdodA==
+  quarkus.mongodb.credentials.password: c3VwZXJmaWdodA==
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: fights-db
+    application: fights-service
+    system: quarkus-super-heroes
+  name: fights-db-config
+data:
+  MONGODB_DATABASE: ZmlnaHRz
+  MONGODB_USERNAME: c3VwZXJmaWdodA==
+  MONGODB_PASSWORD: c3VwZXJmaWdodA==
+  MONGODB_ROOT_USER: c3VwZXI=
+  MONGODB_ROOT_PASSWORD: c3VwZXI=
+type: Opaque

--- a/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/templates/service.yaml
+++ b/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/templates/service.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: fights-db
+    application: fights-service
+    system: quarkus-super-heroes
+  name: fights-db
+spec:
+  ports:
+    - port: 27017
+      protocol: TCP
+      targetPort: 27017
+  selector:
+    name: fights-db
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: fights-kafka
+    application: fights-service
+    system: quarkus-super-heroes
+  name: fights-kafka
+spec:
+  ports:
+    - port: 9092
+      protocol: TCP
+      targetPort: 9092
+  selector:
+    name: fights-kafka
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
+  labels:
+    name: apicurio
+    application: fights-service
+    system: quarkus-super-heroes
+  name: apicurio
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    name: apicurio
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    app.quarkus.io/vcs-ref: main
+    app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "fights-db,fights-kafka,apicurio,rest-villains,rest-heroes,otel-collector"
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:47:03 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8082"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: rest-fights
+    app.kubernetes.io/part-of: fights-service
+    app.kubernetes.io/version: java11-latest
+    app: rest-fights
+    application: fights-service
+    system: quarkus-super-heroes
+  name: rest-fights
+spec:
+  ports:
+    - name: http
+      nodePort: 30489
+      port: 80
+      protocol: TCP
+      targetPort: 8082
+  selector:
+    app.kubernetes.io/name: rest-fights
+    app.kubernetes.io/part-of: fights-service
+    app.kubernetes.io/version: java11-latest
+  type: {{ .Values.app.serviceType }}

--- a/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/values.yaml
+++ b/rest-fights/deploy/helm/minikube/rest-fights-java11-latest-minikube/values.yaml
@@ -1,0 +1,24 @@
+---
+app:
+  serviceType: ClusterIP
+  livenessProbe:
+    failureThreshold: 3
+    periodSeconds: 10
+    timeoutSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/live
+      scheme: HTTP
+      port: 8082
+  image: quay.io/quarkus-super-heroes/rest-fights:java11-latest
+  readinessProbe:
+    failureThreshold: 3
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/ready
+      scheme: HTTP
+      port: 8082

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/Chart.yaml
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/Chart.yaml
@@ -1,0 +1,4 @@
+---
+name: rest-fights-java11-latest-openshift
+version: 1.0.0
+apiVersion: v2

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-heroes-java11-latest-openshift/Chart.yaml
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-heroes-java11-latest-openshift/Chart.yaml
@@ -1,0 +1,4 @@
+---
+name: rest-heroes-java11-latest-openshift
+version: 1.0.0
+apiVersion: v2

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-heroes-java11-latest-openshift/templates/NOTES.txt
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-heroes-java11-latest-openshift/templates/NOTES.txt
@@ -1,0 +1,72 @@
+# Quarkus Helm Notes
+
+To access the Helm annotations or properties you just need to have the following dependency in your
+class path:
+
+    <dependency>
+        <groupId>io.quarkiverse.helm</groupId>
+        <artifactId>quarkus-helm</artifactId>
+        <version>{quarkus-helm-version}</version>
+    </dependency>
+
+Build the project using:
+
+    mvn clean package
+
+You can find the generated Helm artifacts under: `target/helm/kubernetes/<chart name>/` that should look like:
+- Chart.yaml
+- values.yaml
+- templates/*.yml the generated resources by Quarkus Helm
+
+**Note**: The `<chart name>` is set from either the property `quarkus.helm.name` or the `@HelmChart` annotation or the Quarkus application.
+
+# Requirements
+
+- Have installed [the Helm command line](https://helm.sh/docs/intro/install/)
+- Have connected/logged to a kubernetes cluster
+- Configure your Quarkus application to use any of the Quarkus Kubernetes extensions like Quarkus Kubernetes, Quarkus OpenShift or Quarkus Knative.
+- Configure your Quarkus application to use any of [the Quarkus Container Image extensions](https://quarkus.io/guides/container-image) - This example uses `container-image-docker`.
+
+# How can it be used?
+
+You can run the following Maven command in order to generate the Helm artifacts and build/push the image into a container registry:
+
+```shell
+mvn clean package -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=<your container registry> -Dquarkus.container-image.group=<your container registry namespace>
+```
+
+This command will push the image to a container registry and will become available when a pod or container is created.
+
+Finally, let's use Helm to deploy it into the cluster:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name>
+```
+
+The above command will deploy a chart using the default values (as defined within the `values.yaml` file). We can override the default values to use your `values.dev.yaml` file by executing the following command:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name> --values ./target/helm/<chart name>/kubernetes/values.dev.yaml
+```
+
+How can I update my deployment?
+
+- Via the `upgrade` option of Helm command line:
+
+After making changes to your project and regenerating the Helm resources and the application container image, then you need to upgrade your deployment:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name>
+```
+
+- Via the `set` option of Helm command line:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name> --set <app name>.replicas=1
+```
+
+How can we delete my deployment?
+
+```shell
+helm uninstall helm-example
+```

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-heroes-java11-latest-openshift/templates/configmap.yaml
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-heroes-java11-latest-openshift/templates/configmap.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: rest-heroes-config
+data:
+  quarkus.hibernate-orm.database.generation: validate
+  quarkus.hibernate-orm.sql-load-script: no-file
+  quarkus.datasource.reactive.url: postgresql://heroes-db:5432/heroes_database
+  quarkus.opentelemetry.tracer.exporter.otlp.endpoint: http://otel-collector:4317
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: heroes-db-init
+data:
+  get-data.sh: |-
+    #!/bin/bash
+
+    curl https://raw.githubusercontent.com/quarkusio/quarkus-super-heroes/main/rest-heroes/deploy/db-init/initialize-tables.sql --output /docker-entrypoint-initdb.d/1-init-tables.sql

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-heroes-java11-latest-openshift/templates/deployment.yaml
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-heroes-java11-latest-openshift/templates/deployment.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: heroes-service
+    app.openshift.io/runtime: postgresql
+  name: heroes-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: heroes-db
+  template:
+    metadata:
+      labels:
+        name: heroes-db
+        application: heroes-service
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - envFrom:
+            - secretRef:
+                name: heroes-db-config
+          image: bitnami/postgresql:14
+          name: heroes-db
+          ports:
+            - containerPort: 5432
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              memory: 32Mi
+          volumeMounts:
+            - mountPath: /bitnami/postgresql
+              name: heroes-db-data
+            - mountPath: /docker-entrypoint-initdb.d
+              name: heroes-db-init-data
+      initContainers:
+        - command:
+            - sh
+            - get-data.sh
+          image: registry.access.redhat.com/ubi8-minimal:8.6
+          name: get-data
+          volumeMounts:
+            - mountPath: /docker-entrypoint-preinitdb.d
+              name: heroes-db-init
+            - mountPath: /docker-entrypoint-initdb.d
+              name: heroes-db-init-data
+          workingDir: /docker-entrypoint-preinitdb.d
+      volumes:
+        - emptyDir: {}
+          name: heroes-db-data
+        - emptyDir: {}
+          name: heroes-db-init-data
+        - configMap:
+            name: heroes-db-init
+          name: heroes-db-init

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-heroes-java11-latest-openshift/templates/deploymentconfig.yaml
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-heroes-java11-latest-openshift/templates/deploymentconfig.yaml
@@ -1,0 +1,102 @@
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  annotations:
+    app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "heroes-db,otel-collector"
+    app.openshift.io/vcs-ref: main
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:48:42 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8083"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: rest-heroes
+    app.kubernetes.io/part-of: heroes-service
+    app.kubernetes.io/version: java11-latest
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+    app.openshift.io/runtime: quarkus
+  name: rest-heroes
+spec:
+  replicas: 1
+  selector:
+    app.kubernetes.io/version: java11-latest
+    app.kubernetes.io/part-of: heroes-service
+    app.kubernetes.io/name: rest-heroes
+  template:
+    metadata:
+      annotations:
+        app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+        app.openshift.io/connects-to: "heroes-db,otel-collector"
+        app.openshift.io/vcs-ref: main
+        app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+        app.quarkus.io/build-timestamp: 2023-02-20 - 20:48:42 +0000
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /q/metrics
+        prometheus.io/port: "8083"
+        prometheus.io/scheme: http
+      labels:
+        app: rest-heroes
+        application: heroes-service
+        system: quarkus-super-heroes
+        app.openshift.io/runtime: quarkus
+        app.kubernetes.io/version: java11-latest
+        app.kubernetes.io/part-of: heroes-service
+        app.kubernetes.io/name: rest-heroes
+    spec:
+      containers:
+        - env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom:
+            - secretRef:
+                name: rest-heroes-config-creds
+            - configMapRef:
+                name: rest-heroes-config
+          image: {{ .Values.app.image }}
+          imagePullPolicy: Always
+          livenessProbe:
+            failureThreshold: {{ .Values.app.livenessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.livenessProbe.httpGet.path }}
+              port: {{ .Values.app.livenessProbe.httpGet.port }}
+              scheme: {{ .Values.app.livenessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.livenessProbe.timeoutSeconds }}
+          name: rest-heroes
+          ports:
+            - containerPort: 8083
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: {{ .Values.app.readinessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.readinessProbe.httpGet.path }}
+              port: {{ .Values.app.readinessProbe.httpGet.port }}
+              scheme: {{ .Values.app.readinessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.readinessProbe.timeoutSeconds }}
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 256Mi
+  triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+          - rest-heroes
+        from:
+          kind: ImageStreamTag
+          name: rest-heroes:java11-latest
+      type: ImageChange

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-heroes-java11-latest-openshift/templates/imagestream.yaml
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-heroes-java11-latest-openshift/templates/imagestream.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  annotations:
+    app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "heroes-db,otel-collector"
+    app.openshift.io/vcs-ref: main
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:48:42 +0000
+  labels:
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+    app.openshift.io/runtime: quarkus
+    app.kubernetes.io/version: java11-latest
+    app.kubernetes.io/part-of: heroes-service
+    app.kubernetes.io/name: rest-heroes
+  name: rest-heroes
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+    - from:
+        kind: DockerImage
+        name: quay.io/quarkus-super-heroes/rest-heroes:java11-latest
+      importPolicy: {}
+      name: java11-latest
+      referencePolicy:
+        type: Source
+    - from:
+        kind: DockerImage
+        name: quay.io/quarkus-super-heroes/rest-heroes:java17-latest
+      importPolicy: {}
+      name: java17-latest
+      referencePolicy:
+        type: Source
+    - from:
+        kind: DockerImage
+        name: quay.io/quarkus-super-heroes/rest-heroes:native-latest
+      importPolicy: {}
+      name: native-latest
+      referencePolicy:
+        type: Source

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-heroes-java11-latest-openshift/templates/route.yaml
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-heroes-java11-latest-openshift/templates/route.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  annotations:
+    app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "heroes-db,otel-collector"
+    app.openshift.io/vcs-ref: main
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:48:42 +0000
+  labels:
+    app.kubernetes.io/name: rest-heroes
+    app.kubernetes.io/part-of: heroes-service
+    app.kubernetes.io/version: java11-latest
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+    app.openshift.io/runtime: quarkus
+  name: rest-heroes
+spec:
+  port:
+    targetPort: http
+  to:
+    kind: Service
+    name: rest-heroes

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-heroes-java11-latest-openshift/templates/secret.yaml
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-heroes-java11-latest-openshift/templates/secret.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: rest-heroes-config-creds
+data:
+  quarkus.datasource.username: c3VwZXJtYW4=
+  quarkus.datasource.password: c3VwZXJtYW4=
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: heroes-db-config
+data:
+  POSTGRESQL_DATABASE: aGVyb2VzX2RhdGFiYXNl
+  POSTGRESQL_USERNAME: c3VwZXJtYW4=
+  POSTGRESQL_PASSWORD: c3VwZXJtYW4=
+type: Opaque

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-heroes-java11-latest-openshift/templates/service.yaml
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-heroes-java11-latest-openshift/templates/service.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: heroes-db
+spec:
+  ports:
+    - port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    name: heroes-db
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "heroes-db,otel-collector"
+    app.openshift.io/vcs-ref: main
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:48:42 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8083"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: rest-heroes
+    app.kubernetes.io/part-of: heroes-service
+    app.kubernetes.io/version: java11-latest
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+    app.openshift.io/runtime: quarkus
+  name: rest-heroes
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8083
+  selector:
+    app.kubernetes.io/name: rest-heroes
+    app.kubernetes.io/part-of: heroes-service
+    app.kubernetes.io/version: java11-latest
+  type: {{ .Values.app.serviceType }}

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-heroes-java11-latest-openshift/values.yaml
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-heroes-java11-latest-openshift/values.yaml
@@ -1,0 +1,24 @@
+---
+app:
+  serviceType: ClusterIP
+  livenessProbe:
+    failureThreshold: 3
+    periodSeconds: 10
+    timeoutSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/live
+      scheme: HTTP
+      port: 8083
+  image: rest-heroes:java11-latest
+  readinessProbe:
+    failureThreshold: 3
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/ready
+      scheme: HTTP
+      port: 8083

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-villains-java11-latest-openshift/Chart.yaml
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-villains-java11-latest-openshift/Chart.yaml
@@ -1,0 +1,4 @@
+---
+name: rest-villains-java11-latest-openshift
+version: 1.0.0
+apiVersion: v2

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-villains-java11-latest-openshift/templates/NOTES.txt
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-villains-java11-latest-openshift/templates/NOTES.txt
@@ -1,0 +1,72 @@
+# Quarkus Helm Notes
+
+To access the Helm annotations or properties you just need to have the following dependency in your
+class path:
+
+    <dependency>
+        <groupId>io.quarkiverse.helm</groupId>
+        <artifactId>quarkus-helm</artifactId>
+        <version>{quarkus-helm-version}</version>
+    </dependency>
+
+Build the project using:
+
+    mvn clean package
+
+You can find the generated Helm artifacts under: `target/helm/kubernetes/<chart name>/` that should look like:
+- Chart.yaml
+- values.yaml
+- templates/*.yml the generated resources by Quarkus Helm
+
+**Note**: The `<chart name>` is set from either the property `quarkus.helm.name` or the `@HelmChart` annotation or the Quarkus application.
+
+# Requirements
+
+- Have installed [the Helm command line](https://helm.sh/docs/intro/install/)
+- Have connected/logged to a kubernetes cluster
+- Configure your Quarkus application to use any of the Quarkus Kubernetes extensions like Quarkus Kubernetes, Quarkus OpenShift or Quarkus Knative.
+- Configure your Quarkus application to use any of [the Quarkus Container Image extensions](https://quarkus.io/guides/container-image) - This example uses `container-image-docker`.
+
+# How can it be used?
+
+You can run the following Maven command in order to generate the Helm artifacts and build/push the image into a container registry:
+
+```shell
+mvn clean package -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=<your container registry> -Dquarkus.container-image.group=<your container registry namespace>
+```
+
+This command will push the image to a container registry and will become available when a pod or container is created.
+
+Finally, let's use Helm to deploy it into the cluster:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name>
+```
+
+The above command will deploy a chart using the default values (as defined within the `values.yaml` file). We can override the default values to use your `values.dev.yaml` file by executing the following command:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name> --values ./target/helm/<chart name>/kubernetes/values.dev.yaml
+```
+
+How can I update my deployment?
+
+- Via the `upgrade` option of Helm command line:
+
+After making changes to your project and regenerating the Helm resources and the application container image, then you need to upgrade your deployment:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name>
+```
+
+- Via the `set` option of Helm command line:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name> --set <app name>.replicas=1
+```
+
+How can we delete my deployment?
+
+```shell
+helm uninstall helm-example
+```

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-villains-java11-latest-openshift/templates/configmap.yaml
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-villains-java11-latest-openshift/templates/configmap.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+  name: rest-villains-config
+data:
+  quarkus.hibernate-orm.database.generation: validate
+  quarkus.hibernate-orm.sql-load-script: no-file
+  quarkus.datasource.jdbc.url: jdbc:otel:postgresql://villains-db:5432/villains_database
+  quarkus.opentelemetry.tracer.exporter.otlp.endpoint: http://otel-collector:4317
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+  name: villains-db-init
+data:
+  get-data.sh: |-
+    #!/bin/bash
+
+    curl https://raw.githubusercontent.com/quarkusio/quarkus-super-heroes/main/rest-villains/deploy/db-init/initialize-tables.sql --output /docker-entrypoint-initdb.d/1-init-tables.sql

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-villains-java11-latest-openshift/templates/deployment.yaml
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-villains-java11-latest-openshift/templates/deployment.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: villains-service
+    app.openshift.io/runtime: postgresql
+  name: villains-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: villains-db
+  template:
+    metadata:
+      labels:
+        application: villains-service
+        name: villains-db
+    spec:
+      containers:
+        - envFrom:
+            - secretRef:
+                name: villains-db-config
+          image: bitnami/postgresql:14
+          name: villains-db
+          ports:
+            - containerPort: 5432
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              memory: 32Mi
+          volumeMounts:
+            - mountPath: /bitnami/postgresql
+              name: villains-db-data
+            - mountPath: /docker-entrypoint-initdb.d
+              name: villains-db-init-data
+      initContainers:
+        - command:
+            - sh
+            - get-data.sh
+          image: registry.access.redhat.com/ubi8-minimal:8.6
+          name: get-data
+          volumeMounts:
+            - mountPath: /docker-entrypoint-preinitdb.d
+              name: villains-db-init
+            - mountPath: /docker-entrypoint-initdb.d
+              name: villains-db-init-data
+          workingDir: /docker-entrypoint-preinitdb.d
+      volumes:
+        - emptyDir: {}
+          name: villains-db-data
+        - emptyDir: {}
+          name: villains-db-init-data
+        - configMap:
+            name: villains-db-init
+          name: villains-db-init

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-villains-java11-latest-openshift/templates/deploymentconfig.yaml
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-villains-java11-latest-openshift/templates/deploymentconfig.yaml
@@ -1,0 +1,102 @@
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  annotations:
+    app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "villains-db,otel-collector"
+    app.openshift.io/vcs-ref: main
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:48:10 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8084"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: rest-villains
+    app.kubernetes.io/part-of: villains-service
+    app.kubernetes.io/version: java11-latest
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+    app.openshift.io/runtime: quarkus
+  name: rest-villains
+spec:
+  replicas: 1
+  selector:
+    app.kubernetes.io/part-of: villains-service
+    app.kubernetes.io/version: java11-latest
+    app.kubernetes.io/name: rest-villains
+  template:
+    metadata:
+      annotations:
+        app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+        app.openshift.io/connects-to: "villains-db,otel-collector"
+        app.openshift.io/vcs-ref: main
+        app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+        app.quarkus.io/build-timestamp: 2023-02-20 - 20:48:10 +0000
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /q/metrics
+        prometheus.io/port: "8084"
+        prometheus.io/scheme: http
+      labels:
+        app: rest-villains
+        application: villains-service
+        system: quarkus-super-heroes
+        app.openshift.io/runtime: quarkus
+        app.kubernetes.io/part-of: villains-service
+        app.kubernetes.io/version: java11-latest
+        app.kubernetes.io/name: rest-villains
+    spec:
+      containers:
+        - env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom:
+            - secretRef:
+                name: rest-villains-config-creds
+            - configMapRef:
+                name: rest-villains-config
+          image: {{ .Values.app.image }}
+          imagePullPolicy: Always
+          livenessProbe:
+            failureThreshold: {{ .Values.app.livenessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.livenessProbe.httpGet.path }}
+              port: {{ .Values.app.livenessProbe.httpGet.port }}
+              scheme: {{ .Values.app.livenessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.livenessProbe.timeoutSeconds }}
+          name: rest-villains
+          ports:
+            - containerPort: 8084
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: {{ .Values.app.readinessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.readinessProbe.httpGet.path }}
+              port: {{ .Values.app.readinessProbe.httpGet.port }}
+              scheme: {{ .Values.app.readinessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.readinessProbe.timeoutSeconds }}
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 256Mi
+  triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+          - rest-villains
+        from:
+          kind: ImageStreamTag
+          name: rest-villains:java11-latest
+      type: ImageChange

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-villains-java11-latest-openshift/templates/imagestream.yaml
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-villains-java11-latest-openshift/templates/imagestream.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  annotations:
+    app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "villains-db,otel-collector"
+    app.openshift.io/vcs-ref: main
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:48:10 +0000
+  labels:
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+    app.openshift.io/runtime: quarkus
+    app.kubernetes.io/part-of: villains-service
+    app.kubernetes.io/version: java11-latest
+    app.kubernetes.io/name: rest-villains
+  name: rest-villains
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+    - from:
+        kind: DockerImage
+        name: quay.io/quarkus-super-heroes/rest-villains:java11-latest
+      importPolicy: {}
+      name: java11-latest
+      referencePolicy:
+        type: Source
+    - from:
+        kind: DockerImage
+        name: quay.io/quarkus-super-heroes/rest-villains:java17-latest
+      importPolicy: {}
+      name: java17-latest
+      referencePolicy:
+        type: Source
+    - from:
+        kind: DockerImage
+        name: quay.io/quarkus-super-heroes/rest-villains:native-latest
+      importPolicy: {}
+      name: native-latest
+      referencePolicy:
+        type: Source

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-villains-java11-latest-openshift/templates/route.yaml
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-villains-java11-latest-openshift/templates/route.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  annotations:
+    app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "villains-db,otel-collector"
+    app.openshift.io/vcs-ref: main
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:48:10 +0000
+  labels:
+    app.kubernetes.io/name: rest-villains
+    app.kubernetes.io/part-of: villains-service
+    app.kubernetes.io/version: java11-latest
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+    app.openshift.io/runtime: quarkus
+  name: rest-villains
+spec:
+  port:
+    targetPort: http
+  to:
+    kind: Service
+    name: rest-villains

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-villains-java11-latest-openshift/templates/secret.yaml
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-villains-java11-latest-openshift/templates/secret.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+  name: rest-villains-config-creds
+data:
+  quarkus.datasource.username: c3VwZXJiYWQ=
+  quarkus.datasource.password: c3VwZXJiYWQ=
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+  name: villains-db-config
+data:
+  POSTGRESQL_DATABASE: dmlsbGFpbnNfZGF0YWJhc2U=
+  POSTGRESQL_USERNAME: c3VwZXJiYWQ=
+  POSTGRESQL_PASSWORD: c3VwZXJiYWQ=
+type: Opaque

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-villains-java11-latest-openshift/templates/service.yaml
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-villains-java11-latest-openshift/templates/service.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+  name: villains-db
+spec:
+  ports:
+    - port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    name: villains-db
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "villains-db,otel-collector"
+    app.openshift.io/vcs-ref: main
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:48:10 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8084"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: rest-villains
+    app.kubernetes.io/part-of: villains-service
+    app.kubernetes.io/version: java11-latest
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+    app.openshift.io/runtime: quarkus
+  name: rest-villains
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8084
+  selector:
+    app.kubernetes.io/name: rest-villains
+    app.kubernetes.io/part-of: villains-service
+    app.kubernetes.io/version: java11-latest
+  type: {{ .Values.app.serviceType }}

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-villains-java11-latest-openshift/values.yaml
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/charts/rest-villains-java11-latest-openshift/values.yaml
@@ -1,0 +1,24 @@
+---
+app:
+  serviceType: ClusterIP
+  livenessProbe:
+    failureThreshold: 3
+    periodSeconds: 10
+    timeoutSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/live
+      scheme: HTTP
+      port: 8084
+  image: rest-villains:java11-latest
+  readinessProbe:
+    failureThreshold: 3
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/ready
+      scheme: HTTP
+      port: 8084

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/templates/NOTES.txt
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/templates/NOTES.txt
@@ -1,0 +1,72 @@
+# Quarkus Helm Notes
+
+To access the Helm annotations or properties you just need to have the following dependency in your
+class path:
+
+    <dependency>
+        <groupId>io.quarkiverse.helm</groupId>
+        <artifactId>quarkus-helm</artifactId>
+        <version>{quarkus-helm-version}</version>
+    </dependency>
+
+Build the project using:
+
+    mvn clean package
+
+You can find the generated Helm artifacts under: `target/helm/kubernetes/<chart name>/` that should look like:
+- Chart.yaml
+- values.yaml
+- templates/*.yml the generated resources by Quarkus Helm
+
+**Note**: The `<chart name>` is set from either the property `quarkus.helm.name` or the `@HelmChart` annotation or the Quarkus application.
+
+# Requirements
+
+- Have installed [the Helm command line](https://helm.sh/docs/intro/install/)
+- Have connected/logged to a kubernetes cluster
+- Configure your Quarkus application to use any of the Quarkus Kubernetes extensions like Quarkus Kubernetes, Quarkus OpenShift or Quarkus Knative.
+- Configure your Quarkus application to use any of [the Quarkus Container Image extensions](https://quarkus.io/guides/container-image) - This example uses `container-image-docker`.
+
+# How can it be used?
+
+You can run the following Maven command in order to generate the Helm artifacts and build/push the image into a container registry:
+
+```shell
+mvn clean package -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=<your container registry> -Dquarkus.container-image.group=<your container registry namespace>
+```
+
+This command will push the image to a container registry and will become available when a pod or container is created.
+
+Finally, let's use Helm to deploy it into the cluster:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name>
+```
+
+The above command will deploy a chart using the default values (as defined within the `values.yaml` file). We can override the default values to use your `values.dev.yaml` file by executing the following command:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name> --values ./target/helm/<chart name>/kubernetes/values.dev.yaml
+```
+
+How can I update my deployment?
+
+- Via the `upgrade` option of Helm command line:
+
+After making changes to your project and regenerating the Helm resources and the application container image, then you need to upgrade your deployment:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name>
+```
+
+- Via the `set` option of Helm command line:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name> --set <app name>.replicas=1
+```
+
+How can we delete my deployment?
+
+```shell
+helm uninstall helm-example
+```

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/templates/configmap.yaml
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/templates/configmap.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: rest-fights
+    application: fights-service
+    system: quarkus-super-heroes
+  name: rest-fights-config
+data:
+  quarkus.liquibase-mongodb.migrate-at-start: "false"
+  quarkus.mongodb.hosts: fights-db:27017
+  quarkus.stork.hero-service.service-discovery.type: kubernetes
+  quarkus.stork.hero-service.service-discovery.application: rest-heroes
+  quarkus.stork.hero-service.service-discovery.refresh-period: 1M
+  quarkus.stork.villain-service.service-discovery.type: kubernetes
+  quarkus.stork.villain-service.service-discovery.application: rest-villains
+  quarkus.stork.villain-service.service-discovery.refresh-period: 1M
+  quarkus.opentelemetry.tracer.exporter.otlp.endpoint: http://otel-collector:4317
+  kafka.bootstrap.servers: PLAINTEXT://fights-kafka:9092
+  mp.messaging.connector.smallrye-kafka.apicurio.registry.url: http://apicurio:8080/apis/registry/v2

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/templates/deployment.yaml
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/templates/deployment.yaml
@@ -1,0 +1,148 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: fights-db
+    application: fights-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: fights-service
+    app.openshift.io/runtime: mongodb
+  name: fights-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: fights-db
+  template:
+    metadata:
+      labels:
+        application: fights-service
+        name: fights-db
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - envFrom:
+            - secretRef:
+                name: fights-db-config
+          image: bitnami/mongodb:5.0
+          name: fights-db
+          ports:
+            - containerPort: 27017
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              memory: 64Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: fights-kafka
+    application: fights-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: fights-service
+    app.openshift.io/runtime: amq
+  name: fights-kafka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: fights-kafka
+  template:
+    metadata:
+      labels:
+        application: fights-service
+        name: fights-kafka
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - command:
+            - sh
+            - -c
+            - "export CLUSTER_ID=$(bin/kafka-storage.sh random-uuid) && bin/kafka-storage.sh format -t ${CLUSTER_ID} -c config/kraft/server.properties && bin/kafka-server-start.sh config/kraft/server.properties --override advertised.listeners=${KAFKA_ADVERTISED_LISTENERS}"
+          env:
+            - name: LOG_DIR
+              value: /tmp/logs
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: PLAINTEXT://fights-kafka:9092
+          image: quay.io/strimzi/kafka:0.28.0-kafka-3.1.0
+          name: fights-kafka
+          ports:
+            - containerPort: 9092
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 128Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
+  labels:
+    app: apicurio
+    application: fights-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: fights-service
+    app.kubernetes.io/name: apicurio
+    app.kubernetes.io/version: 2.2.3.Final
+    app.openshift.io/runtime: apicurio
+  name: apicurio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: apicurio
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scheme: http
+      labels:
+        application: fights-service
+        name: apicurio
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - env:
+            - name: REGISTRY_AUTH_ANONYMOUS_READ_ACCESS_ENABLED
+              value: "true"
+          image: quay.io/apicurio/apicurio-registry-mem:2.2.3.Final
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health/live
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          name: apicurio
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health/ready
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 128Mi

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/templates/deploymentconfig.yaml
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/templates/deploymentconfig.yaml
@@ -1,0 +1,102 @@
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  annotations:
+    app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "fights-db,fights-kafka,apicurio,rest-villains,rest-heroes,otel-collector"
+    app.openshift.io/vcs-ref: main
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:49:17 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8082"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: rest-fights
+    app.kubernetes.io/part-of: fights-service
+    app.kubernetes.io/version: java11-latest
+    app: rest-fights
+    application: fights-service
+    system: quarkus-super-heroes
+    app.openshift.io/runtime: quarkus
+  name: rest-fights
+spec:
+  replicas: 1
+  selector:
+    app.kubernetes.io/version: java11-latest
+    app.kubernetes.io/part-of: fights-service
+    app.kubernetes.io/name: rest-fights
+  template:
+    metadata:
+      annotations:
+        app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+        app.openshift.io/connects-to: "fights-db,fights-kafka,apicurio,rest-villains,rest-heroes,otel-collector"
+        app.openshift.io/vcs-ref: main
+        app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+        app.quarkus.io/build-timestamp: 2023-02-20 - 20:49:17 +0000
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /q/metrics
+        prometheus.io/port: "8082"
+        prometheus.io/scheme: http
+      labels:
+        app: rest-fights
+        application: fights-service
+        system: quarkus-super-heroes
+        app.openshift.io/runtime: quarkus
+        app.kubernetes.io/version: java11-latest
+        app.kubernetes.io/part-of: fights-service
+        app.kubernetes.io/name: rest-fights
+    spec:
+      containers:
+        - env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom:
+            - configMapRef:
+                name: rest-fights-config
+            - secretRef:
+                name: rest-fights-config-creds
+          image: {{ .Values.app.image }}
+          imagePullPolicy: Always
+          livenessProbe:
+            failureThreshold: {{ .Values.app.livenessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.livenessProbe.httpGet.path }}
+              port: {{ .Values.app.livenessProbe.httpGet.port }}
+              scheme: {{ .Values.app.livenessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.livenessProbe.timeoutSeconds }}
+          name: rest-fights
+          ports:
+            - containerPort: 8082
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: {{ .Values.app.readinessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.readinessProbe.httpGet.path }}
+              port: {{ .Values.app.readinessProbe.httpGet.port }}
+              scheme: {{ .Values.app.readinessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.readinessProbe.timeoutSeconds }}
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 256Mi
+  triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+          - rest-fights
+        from:
+          kind: ImageStreamTag
+          name: rest-fights:java11-latest
+      type: ImageChange

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/templates/imagestream.yaml
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/templates/imagestream.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  annotations:
+    app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "fights-db,fights-kafka,apicurio,rest-villains,rest-heroes,otel-collector"
+    app.openshift.io/vcs-ref: main
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:49:17 +0000
+  labels:
+    app: rest-fights
+    application: fights-service
+    system: quarkus-super-heroes
+    app.openshift.io/runtime: quarkus
+    app.kubernetes.io/version: java11-latest
+    app.kubernetes.io/part-of: fights-service
+    app.kubernetes.io/name: rest-fights
+  name: rest-fights
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+    - from:
+        kind: DockerImage
+        name: quay.io/quarkus-super-heroes/rest-fights:java11-latest
+      importPolicy: {}
+      name: java11-latest
+      referencePolicy:
+        type: Source
+    - from:
+        kind: DockerImage
+        name: quay.io/quarkus-super-heroes/rest-fights:java17-latest
+      importPolicy: {}
+      name: java17-latest
+      referencePolicy:
+        type: Source
+    - from:
+        kind: DockerImage
+        name: quay.io/quarkus-super-heroes/rest-fights:native-latest
+      importPolicy: {}
+      name: native-latest
+      referencePolicy:
+        type: Source

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/templates/rolebinding.yaml
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/templates/rolebinding.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: default_view
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: default

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/templates/route.yaml
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/templates/route.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
+  labels:
+    app: apicurio
+    application: fights-service
+    system: quarkus-super-heroes
+    app.openshift.io/runtime: apicurio
+  name: apicurio
+spec:
+  port:
+    targetPort: 8080
+  to:
+    kind: Service
+    name: apicurio
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  annotations:
+    app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "fights-db,fights-kafka,apicurio,rest-villains,rest-heroes,otel-collector"
+    app.openshift.io/vcs-ref: main
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:49:17 +0000
+  labels:
+    app.kubernetes.io/name: rest-fights
+    app.kubernetes.io/part-of: fights-service
+    app.kubernetes.io/version: java11-latest
+    app: rest-fights
+    application: fights-service
+    system: quarkus-super-heroes
+    app.openshift.io/runtime: quarkus
+  name: rest-fights
+spec:
+  port:
+    targetPort: http
+  to:
+    kind: Service
+    name: rest-fights

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/templates/secret.yaml
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/templates/secret.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: rest-fights
+    application: fights-service
+    system: quarkus-super-heroes
+  name: rest-fights-config-creds
+data:
+  quarkus.mongodb.credentials.username: c3VwZXJmaWdodA==
+  quarkus.mongodb.credentials.password: c3VwZXJmaWdodA==
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: fights-db
+    application: fights-service
+    system: quarkus-super-heroes
+  name: fights-db-config
+data:
+  MONGODB_DATABASE: ZmlnaHRz
+  MONGODB_USERNAME: c3VwZXJmaWdodA==
+  MONGODB_PASSWORD: c3VwZXJmaWdodA==
+  MONGODB_ROOT_USER: c3VwZXI=
+  MONGODB_ROOT_PASSWORD: c3VwZXI=
+type: Opaque

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/templates/service.yaml
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/templates/service.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: fights-db
+    application: fights-service
+    system: quarkus-super-heroes
+  name: fights-db
+spec:
+  ports:
+    - port: 27017
+      protocol: TCP
+      targetPort: 27017
+  selector:
+    name: fights-db
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: fights-kafka
+    application: fights-service
+    system: quarkus-super-heroes
+  name: fights-kafka
+spec:
+  ports:
+    - port: 9092
+      protocol: TCP
+      targetPort: 9092
+  selector:
+    name: fights-kafka
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
+  labels:
+    name: apicurio
+    application: fights-service
+    system: quarkus-super-heroes
+  name: apicurio
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    name: apicurio
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "fights-db,fights-kafka,apicurio,rest-villains,rest-heroes,otel-collector"
+    app.openshift.io/vcs-ref: main
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:49:17 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8082"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: rest-fights
+    app.kubernetes.io/part-of: fights-service
+    app.kubernetes.io/version: java11-latest
+    app: rest-fights
+    application: fights-service
+    system: quarkus-super-heroes
+    app.openshift.io/runtime: quarkus
+  name: rest-fights
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8082
+  selector:
+    app.kubernetes.io/name: rest-fights
+    app.kubernetes.io/part-of: fights-service
+    app.kubernetes.io/version: java11-latest
+  type: {{ .Values.app.serviceType }}

--- a/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/values.yaml
+++ b/rest-fights/deploy/helm/openshift/rest-fights-java11-latest-openshift/values.yaml
@@ -1,0 +1,24 @@
+---
+app:
+  serviceType: ClusterIP
+  livenessProbe:
+    failureThreshold: 3
+    periodSeconds: 10
+    timeoutSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/live
+      scheme: HTTP
+      port: 8082
+  image: quay.io/quarkus-super-heroes/rest-fights:java11-latest
+  readinessProbe:
+    failureThreshold: 3
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/ready
+      scheme: HTTP
+      port: 8082

--- a/rest-fights/pom.xml
+++ b/rest-fights/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.quarkus.sample.super-heroes</groupId>
   <artifactId>rest-fights</artifactId>
-  <version>1.0</version>
+  <version>java11-latest</version>
   <name>Quarkus Sample :: Super-Heroes :: Fights Microservice</name>
   <properties>
     <assertj.version>3.24.2</assertj.version>
@@ -153,6 +153,11 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-opentelemetry</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkiverse.helm</groupId>
+      <artifactId>quarkus-helm</artifactId>
+      <version>0.2.5</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/rest-heroes/deploy/helm/knative/rest-heroes-java11-latest-knative/Chart.yaml
+++ b/rest-heroes/deploy/helm/knative/rest-heroes-java11-latest-knative/Chart.yaml
@@ -1,0 +1,4 @@
+---
+name: rest-heroes-java11-latest-knative
+version: 1.0.0
+apiVersion: v2

--- a/rest-heroes/deploy/helm/knative/rest-heroes-java11-latest-knative/templates/NOTES.txt
+++ b/rest-heroes/deploy/helm/knative/rest-heroes-java11-latest-knative/templates/NOTES.txt
@@ -1,0 +1,72 @@
+# Quarkus Helm Notes
+
+To access the Helm annotations or properties you just need to have the following dependency in your
+class path:
+
+    <dependency>
+        <groupId>io.quarkiverse.helm</groupId>
+        <artifactId>quarkus-helm</artifactId>
+        <version>{quarkus-helm-version}</version>
+    </dependency>
+
+Build the project using:
+
+    mvn clean package
+
+You can find the generated Helm artifacts under: `target/helm/kubernetes/<chart name>/` that should look like:
+- Chart.yaml
+- values.yaml
+- templates/*.yml the generated resources by Quarkus Helm
+
+**Note**: The `<chart name>` is set from either the property `quarkus.helm.name` or the `@HelmChart` annotation or the Quarkus application.
+
+# Requirements
+
+- Have installed [the Helm command line](https://helm.sh/docs/intro/install/)
+- Have connected/logged to a kubernetes cluster
+- Configure your Quarkus application to use any of the Quarkus Kubernetes extensions like Quarkus Kubernetes, Quarkus OpenShift or Quarkus Knative.
+- Configure your Quarkus application to use any of [the Quarkus Container Image extensions](https://quarkus.io/guides/container-image) - This example uses `container-image-docker`.
+
+# How can it be used?
+
+You can run the following Maven command in order to generate the Helm artifacts and build/push the image into a container registry:
+
+```shell
+mvn clean package -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=<your container registry> -Dquarkus.container-image.group=<your container registry namespace>
+```
+
+This command will push the image to a container registry and will become available when a pod or container is created.
+
+Finally, let's use Helm to deploy it into the cluster:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name>
+```
+
+The above command will deploy a chart using the default values (as defined within the `values.yaml` file). We can override the default values to use your `values.dev.yaml` file by executing the following command:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name> --values ./target/helm/<chart name>/kubernetes/values.dev.yaml
+```
+
+How can I update my deployment?
+
+- Via the `upgrade` option of Helm command line:
+
+After making changes to your project and regenerating the Helm resources and the application container image, then you need to upgrade your deployment:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name>
+```
+
+- Via the `set` option of Helm command line:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name> --set <app name>.replicas=1
+```
+
+How can we delete my deployment?
+
+```shell
+helm uninstall helm-example
+```

--- a/rest-heroes/deploy/helm/knative/rest-heroes-java11-latest-knative/templates/configmap.yaml
+++ b/rest-heroes/deploy/helm/knative/rest-heroes-java11-latest-knative/templates/configmap.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: rest-heroes-config
+data:
+  quarkus.hibernate-orm.database.generation: validate
+  quarkus.hibernate-orm.sql-load-script: no-file
+  quarkus.datasource.reactive.url: postgresql://heroes-db:5432/heroes_database
+  quarkus.opentelemetry.tracer.exporter.otlp.endpoint: http://otel-collector:4317
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: heroes-db-init
+data:
+  get-data.sh: |-
+    #!/bin/bash
+
+    curl https://raw.githubusercontent.com/quarkusio/quarkus-super-heroes/main/rest-heroes/deploy/db-init/initialize-tables.sql --output /docker-entrypoint-initdb.d/1-init-tables.sql

--- a/rest-heroes/deploy/helm/knative/rest-heroes-java11-latest-knative/templates/deployment.yaml
+++ b/rest-heroes/deploy/helm/knative/rest-heroes-java11-latest-knative/templates/deployment.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: heroes-service
+    app.openshift.io/runtime: postgresql
+  name: heroes-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: heroes-db
+  template:
+    metadata:
+      labels:
+        name: heroes-db
+        application: heroes-service
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - envFrom:
+            - secretRef:
+                name: heroes-db-config
+          image: bitnami/postgresql:14
+          name: heroes-db
+          ports:
+            - containerPort: 5432
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              memory: 32Mi
+          volumeMounts:
+            - mountPath: /bitnami/postgresql
+              name: heroes-db-data
+            - mountPath: /docker-entrypoint-initdb.d
+              name: heroes-db-init-data
+      initContainers:
+        - command:
+            - sh
+            - get-data.sh
+          image: registry.access.redhat.com/ubi8-minimal:8.6
+          name: get-data
+          volumeMounts:
+            - mountPath: /docker-entrypoint-preinitdb.d
+              name: heroes-db-init
+            - mountPath: /docker-entrypoint-initdb.d
+              name: heroes-db-init-data
+          workingDir: /docker-entrypoint-preinitdb.d
+      volumes:
+        - emptyDir: {}
+          name: heroes-db-data
+        - emptyDir: {}
+          name: heroes-db-init-data
+        - configMap:
+            name: heroes-db-init
+          name: heroes-db-init

--- a/rest-heroes/deploy/helm/knative/rest-heroes-java11-latest-knative/templates/secret.yaml
+++ b/rest-heroes/deploy/helm/knative/rest-heroes-java11-latest-knative/templates/secret.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: rest-heroes-config-creds
+data:
+  quarkus.datasource.username: c3VwZXJtYW4=
+  quarkus.datasource.password: c3VwZXJtYW4=
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: heroes-db-config
+data:
+  POSTGRESQL_DATABASE: aGVyb2VzX2RhdGFiYXNl
+  POSTGRESQL_USERNAME: c3VwZXJtYW4=
+  POSTGRESQL_PASSWORD: c3VwZXJtYW4=
+type: Opaque

--- a/rest-heroes/deploy/helm/knative/rest-heroes-java11-latest-knative/templates/service.yaml
+++ b/rest-heroes/deploy/helm/knative/rest-heroes-java11-latest-knative/templates/service.yaml
@@ -1,0 +1,81 @@
+---
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  annotations:
+    app.openshift.io/connects-to: "heroes-db,otel-collector"
+    app.openshift.io/vcs-ref: main
+    app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:50:59 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8083"
+    prometheus.io/scheme: http
+  labels:
+    app: rest-heroes
+    app.openshift.io/runtime: quarkus
+    application: heroes-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/version: java11-latest
+    app.kubernetes.io/name: rest-heroes
+    app.kubernetes.io/part-of: heroes-service
+  name: rest-heroes
+spec:
+  template:
+    spec:
+      containers:
+        - envFrom:
+            - configMapRef:
+                name: rest-heroes-config
+            - secretRef:
+                name: rest-heroes-config-creds
+          image: {{ .Values.app.image }}
+          imagePullPolicy: Always
+          livenessProbe:
+            failureThreshold: {{ .Values.app.livenessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.livenessProbe.httpGet.path }}
+              port: {{ .Values.app.livenessProbe.httpGet.port }}
+              scheme: {{ .Values.app.livenessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.livenessProbe.timeoutSeconds }}
+          name: rest-heroes
+          ports:
+            - containerPort: 8083
+              name: http1
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: {{ .Values.app.readinessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.readinessProbe.httpGet.path }}
+              port: {{ .Values.app.readinessProbe.httpGet.port }}
+              scheme: {{ .Values.app.readinessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.readinessProbe.timeoutSeconds }}
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: heroes-db
+spec:
+  ports:
+    - port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    name: heroes-db
+  type: ClusterIP

--- a/rest-heroes/deploy/helm/knative/rest-heroes-java11-latest-knative/values.yaml
+++ b/rest-heroes/deploy/helm/knative/rest-heroes-java11-latest-knative/values.yaml
@@ -1,0 +1,24 @@
+---
+app:
+  serviceType: ClusterIP
+  livenessProbe:
+    failureThreshold: 3
+    periodSeconds: 10
+    timeoutSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/live
+      scheme: HTTP
+      port: ":START:{{ .Values.app.livenessProbe.httpGet.port }}:END:"
+  image: rest-heroes:java11-latest
+  readinessProbe:
+    failureThreshold: 3
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/ready
+      scheme: HTTP
+      port: ":START:{{ .Values.app.readinessProbe.httpGet.port }}:END:"

--- a/rest-heroes/deploy/helm/kubernetes/rest-heroes-java11-latest-kubernetes/Chart.yaml
+++ b/rest-heroes/deploy/helm/kubernetes/rest-heroes-java11-latest-kubernetes/Chart.yaml
@@ -1,0 +1,4 @@
+---
+name: rest-heroes-java11-latest-kubernetes
+version: 1.0.0
+apiVersion: v2

--- a/rest-heroes/deploy/helm/kubernetes/rest-heroes-java11-latest-kubernetes/templates/NOTES.txt
+++ b/rest-heroes/deploy/helm/kubernetes/rest-heroes-java11-latest-kubernetes/templates/NOTES.txt
@@ -1,0 +1,72 @@
+# Quarkus Helm Notes
+
+To access the Helm annotations or properties you just need to have the following dependency in your
+class path:
+
+    <dependency>
+        <groupId>io.quarkiverse.helm</groupId>
+        <artifactId>quarkus-helm</artifactId>
+        <version>{quarkus-helm-version}</version>
+    </dependency>
+
+Build the project using:
+
+    mvn clean package
+
+You can find the generated Helm artifacts under: `target/helm/kubernetes/<chart name>/` that should look like:
+- Chart.yaml
+- values.yaml
+- templates/*.yml the generated resources by Quarkus Helm
+
+**Note**: The `<chart name>` is set from either the property `quarkus.helm.name` or the `@HelmChart` annotation or the Quarkus application.
+
+# Requirements
+
+- Have installed [the Helm command line](https://helm.sh/docs/intro/install/)
+- Have connected/logged to a kubernetes cluster
+- Configure your Quarkus application to use any of the Quarkus Kubernetes extensions like Quarkus Kubernetes, Quarkus OpenShift or Quarkus Knative.
+- Configure your Quarkus application to use any of [the Quarkus Container Image extensions](https://quarkus.io/guides/container-image) - This example uses `container-image-docker`.
+
+# How can it be used?
+
+You can run the following Maven command in order to generate the Helm artifacts and build/push the image into a container registry:
+
+```shell
+mvn clean package -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=<your container registry> -Dquarkus.container-image.group=<your container registry namespace>
+```
+
+This command will push the image to a container registry and will become available when a pod or container is created.
+
+Finally, let's use Helm to deploy it into the cluster:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name>
+```
+
+The above command will deploy a chart using the default values (as defined within the `values.yaml` file). We can override the default values to use your `values.dev.yaml` file by executing the following command:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name> --values ./target/helm/<chart name>/kubernetes/values.dev.yaml
+```
+
+How can I update my deployment?
+
+- Via the `upgrade` option of Helm command line:
+
+After making changes to your project and regenerating the Helm resources and the application container image, then you need to upgrade your deployment:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name>
+```
+
+- Via the `set` option of Helm command line:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name> --set <app name>.replicas=1
+```
+
+How can we delete my deployment?
+
+```shell
+helm uninstall helm-example
+```

--- a/rest-heroes/deploy/helm/kubernetes/rest-heroes-java11-latest-kubernetes/templates/configmap.yaml
+++ b/rest-heroes/deploy/helm/kubernetes/rest-heroes-java11-latest-kubernetes/templates/configmap.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: rest-heroes-config
+data:
+  quarkus.hibernate-orm.database.generation: validate
+  quarkus.hibernate-orm.sql-load-script: no-file
+  quarkus.datasource.reactive.url: postgresql://heroes-db:5432/heroes_database
+  quarkus.opentelemetry.tracer.exporter.otlp.endpoint: http://otel-collector:4317
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: heroes-db-init
+data:
+  get-data.sh: |-
+    #!/bin/bash
+
+    curl https://raw.githubusercontent.com/quarkusio/quarkus-super-heroes/main/rest-heroes/deploy/db-init/initialize-tables.sql --output /docker-entrypoint-initdb.d/1-init-tables.sql

--- a/rest-heroes/deploy/helm/kubernetes/rest-heroes-java11-latest-kubernetes/templates/deployment.yaml
+++ b/rest-heroes/deploy/helm/kubernetes/rest-heroes-java11-latest-kubernetes/templates/deployment.yaml
@@ -1,0 +1,153 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    app.openshift.io/connects-to: "heroes-db,otel-collector"
+    app.quarkus.io/vcs-ref: main
+    app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:43:47 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8083"
+    prometheus.io/scheme: http
+  labels:
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/version: java11-latest
+    app.kubernetes.io/part-of: heroes-service
+    app.kubernetes.io/name: rest-heroes
+  name: rest-heroes
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/version: java11-latest
+      app.kubernetes.io/part-of: heroes-service
+      app.kubernetes.io/name: rest-heroes
+  template:
+    metadata:
+      annotations:
+        app.openshift.io/connects-to: "heroes-db,otel-collector"
+        app.quarkus.io/vcs-ref: main
+        app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+        app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+        app.quarkus.io/build-timestamp: 2023-02-20 - 20:43:47 +0000
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /q/metrics
+        prometheus.io/port: "8083"
+        prometheus.io/scheme: http
+      labels:
+        app: rest-heroes
+        application: heroes-service
+        system: quarkus-super-heroes
+        app.kubernetes.io/version: java11-latest
+        app.kubernetes.io/part-of: heroes-service
+        app.kubernetes.io/name: rest-heroes
+    spec:
+      containers:
+        - env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom:
+            - configMapRef:
+                name: rest-heroes-config
+            - secretRef:
+                name: rest-heroes-config-creds
+          image: {{ .Values.app.image }}
+          imagePullPolicy: Always
+          livenessProbe:
+            failureThreshold: {{ .Values.app.livenessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.livenessProbe.httpGet.path }}
+              port: {{ .Values.app.livenessProbe.httpGet.port }}
+              scheme: {{ .Values.app.livenessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.livenessProbe.timeoutSeconds }}
+          name: rest-heroes
+          ports:
+            - containerPort: 8083
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: {{ .Values.app.readinessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.readinessProbe.httpGet.path }}
+              port: {{ .Values.app.readinessProbe.httpGet.port }}
+              scheme: {{ .Values.app.readinessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.readinessProbe.timeoutSeconds }}
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 256Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: heroes-service
+    app.openshift.io/runtime: postgresql
+  name: heroes-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: heroes-db
+  template:
+    metadata:
+      labels:
+        name: heroes-db
+        application: heroes-service
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - envFrom:
+            - secretRef:
+                name: heroes-db-config
+          image: bitnami/postgresql:14
+          name: heroes-db
+          ports:
+            - containerPort: 5432
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              memory: 32Mi
+          volumeMounts:
+            - mountPath: /bitnami/postgresql
+              name: heroes-db-data
+            - mountPath: /docker-entrypoint-initdb.d
+              name: heroes-db-init-data
+      initContainers:
+        - command:
+            - sh
+            - get-data.sh
+          image: registry.access.redhat.com/ubi8-minimal:8.6
+          name: get-data
+          volumeMounts:
+            - mountPath: /docker-entrypoint-preinitdb.d
+              name: heroes-db-init
+            - mountPath: /docker-entrypoint-initdb.d
+              name: heroes-db-init-data
+          workingDir: /docker-entrypoint-preinitdb.d
+      volumes:
+        - emptyDir: {}
+          name: heroes-db-data
+        - emptyDir: {}
+          name: heroes-db-init-data
+        - configMap:
+            name: heroes-db-init
+          name: heroes-db-init

--- a/rest-heroes/deploy/helm/kubernetes/rest-heroes-java11-latest-kubernetes/templates/secret.yaml
+++ b/rest-heroes/deploy/helm/kubernetes/rest-heroes-java11-latest-kubernetes/templates/secret.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: rest-heroes-config-creds
+data:
+  quarkus.datasource.username: c3VwZXJtYW4=
+  quarkus.datasource.password: c3VwZXJtYW4=
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: heroes-db-config
+data:
+  POSTGRESQL_DATABASE: aGVyb2VzX2RhdGFiYXNl
+  POSTGRESQL_USERNAME: c3VwZXJtYW4=
+  POSTGRESQL_PASSWORD: c3VwZXJtYW4=
+type: Opaque

--- a/rest-heroes/deploy/helm/kubernetes/rest-heroes-java11-latest-kubernetes/templates/service.yaml
+++ b/rest-heroes/deploy/helm/kubernetes/rest-heroes-java11-latest-kubernetes/templates/service.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: heroes-db
+spec:
+  ports:
+    - port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    name: heroes-db
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    app.openshift.io/connects-to: "heroes-db,otel-collector"
+    app.quarkus.io/vcs-ref: main
+    app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:43:47 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8083"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: rest-heroes
+    app.kubernetes.io/part-of: heroes-service
+    app.kubernetes.io/version: java11-latest
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: rest-heroes
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8083
+  selector:
+    app.kubernetes.io/name: rest-heroes
+    app.kubernetes.io/part-of: heroes-service
+    app.kubernetes.io/version: java11-latest
+  type: {{ .Values.app.serviceType }}

--- a/rest-heroes/deploy/helm/kubernetes/rest-heroes-java11-latest-kubernetes/values.yaml
+++ b/rest-heroes/deploy/helm/kubernetes/rest-heroes-java11-latest-kubernetes/values.yaml
@@ -1,0 +1,24 @@
+---
+app:
+  serviceType: ClusterIP
+  livenessProbe:
+    failureThreshold: 3
+    periodSeconds: 10
+    timeoutSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/live
+      scheme: HTTP
+      port: 8083
+  image: quay.io/quarkus-super-heroes/rest-heroes:java11-latest
+  readinessProbe:
+    failureThreshold: 3
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/ready
+      scheme: HTTP
+      port: 8083

--- a/rest-heroes/deploy/helm/minikube/rest-heroes-java11-latest-minikube/Chart.yaml
+++ b/rest-heroes/deploy/helm/minikube/rest-heroes-java11-latest-minikube/Chart.yaml
@@ -1,0 +1,4 @@
+---
+name: rest-heroes-java11-latest-minikube
+version: 1.0.0
+apiVersion: v2

--- a/rest-heroes/deploy/helm/minikube/rest-heroes-java11-latest-minikube/templates/NOTES.txt
+++ b/rest-heroes/deploy/helm/minikube/rest-heroes-java11-latest-minikube/templates/NOTES.txt
@@ -1,0 +1,72 @@
+# Quarkus Helm Notes
+
+To access the Helm annotations or properties you just need to have the following dependency in your
+class path:
+
+    <dependency>
+        <groupId>io.quarkiverse.helm</groupId>
+        <artifactId>quarkus-helm</artifactId>
+        <version>{quarkus-helm-version}</version>
+    </dependency>
+
+Build the project using:
+
+    mvn clean package
+
+You can find the generated Helm artifacts under: `target/helm/kubernetes/<chart name>/` that should look like:
+- Chart.yaml
+- values.yaml
+- templates/*.yml the generated resources by Quarkus Helm
+
+**Note**: The `<chart name>` is set from either the property `quarkus.helm.name` or the `@HelmChart` annotation or the Quarkus application.
+
+# Requirements
+
+- Have installed [the Helm command line](https://helm.sh/docs/intro/install/)
+- Have connected/logged to a kubernetes cluster
+- Configure your Quarkus application to use any of the Quarkus Kubernetes extensions like Quarkus Kubernetes, Quarkus OpenShift or Quarkus Knative.
+- Configure your Quarkus application to use any of [the Quarkus Container Image extensions](https://quarkus.io/guides/container-image) - This example uses `container-image-docker`.
+
+# How can it be used?
+
+You can run the following Maven command in order to generate the Helm artifacts and build/push the image into a container registry:
+
+```shell
+mvn clean package -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=<your container registry> -Dquarkus.container-image.group=<your container registry namespace>
+```
+
+This command will push the image to a container registry and will become available when a pod or container is created.
+
+Finally, let's use Helm to deploy it into the cluster:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name>
+```
+
+The above command will deploy a chart using the default values (as defined within the `values.yaml` file). We can override the default values to use your `values.dev.yaml` file by executing the following command:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name> --values ./target/helm/<chart name>/kubernetes/values.dev.yaml
+```
+
+How can I update my deployment?
+
+- Via the `upgrade` option of Helm command line:
+
+After making changes to your project and regenerating the Helm resources and the application container image, then you need to upgrade your deployment:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name>
+```
+
+- Via the `set` option of Helm command line:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name> --set <app name>.replicas=1
+```
+
+How can we delete my deployment?
+
+```shell
+helm uninstall helm-example
+```

--- a/rest-heroes/deploy/helm/minikube/rest-heroes-java11-latest-minikube/templates/configmap.yaml
+++ b/rest-heroes/deploy/helm/minikube/rest-heroes-java11-latest-minikube/templates/configmap.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: rest-heroes-config
+data:
+  quarkus.hibernate-orm.database.generation: validate
+  quarkus.hibernate-orm.sql-load-script: no-file
+  quarkus.datasource.reactive.url: postgresql://heroes-db:5432/heroes_database
+  quarkus.opentelemetry.tracer.exporter.otlp.endpoint: http://otel-collector:4317
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: heroes-db-init
+data:
+  get-data.sh: |-
+    #!/bin/bash
+
+    curl https://raw.githubusercontent.com/quarkusio/quarkus-super-heroes/main/rest-heroes/deploy/db-init/initialize-tables.sql --output /docker-entrypoint-initdb.d/1-init-tables.sql

--- a/rest-heroes/deploy/helm/minikube/rest-heroes-java11-latest-minikube/templates/deployment.yaml
+++ b/rest-heroes/deploy/helm/minikube/rest-heroes-java11-latest-minikube/templates/deployment.yaml
@@ -1,0 +1,153 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    app.quarkus.io/vcs-ref: main
+    app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "heroes-db,otel-collector"
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:46:26 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8083"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: rest-heroes
+    app.kubernetes.io/part-of: heroes-service
+    app.kubernetes.io/version: java11-latest
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: rest-heroes
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: rest-heroes
+      app.kubernetes.io/part-of: heroes-service
+      app.kubernetes.io/version: java11-latest
+  template:
+    metadata:
+      annotations:
+        app.quarkus.io/vcs-ref: main
+        app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+        app.openshift.io/connects-to: "heroes-db,otel-collector"
+        app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+        app.quarkus.io/build-timestamp: 2023-02-20 - 20:46:26 +0000
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /q/metrics
+        prometheus.io/port: "8083"
+        prometheus.io/scheme: http
+      labels:
+        app.kubernetes.io/name: rest-heroes
+        app.kubernetes.io/part-of: heroes-service
+        app.kubernetes.io/version: java11-latest
+        app: rest-heroes
+        application: heroes-service
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom:
+            - configMapRef:
+                name: rest-heroes-config
+            - secretRef:
+                name: rest-heroes-config-creds
+          image: {{ .Values.app.image }}
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: {{ .Values.app.livenessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.livenessProbe.httpGet.path }}
+              port: {{ .Values.app.livenessProbe.httpGet.port }}
+              scheme: {{ .Values.app.livenessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.livenessProbe.timeoutSeconds }}
+          name: rest-heroes
+          ports:
+            - containerPort: 8083
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: {{ .Values.app.readinessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.readinessProbe.httpGet.path }}
+              port: {{ .Values.app.readinessProbe.httpGet.port }}
+              scheme: {{ .Values.app.readinessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.readinessProbe.timeoutSeconds }}
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 256Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: heroes-service
+    app.openshift.io/runtime: postgresql
+  name: heroes-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: heroes-db
+  template:
+    metadata:
+      labels:
+        name: heroes-db
+        application: heroes-service
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - envFrom:
+            - secretRef:
+                name: heroes-db-config
+          image: bitnami/postgresql:14
+          name: heroes-db
+          ports:
+            - containerPort: 5432
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              memory: 32Mi
+          volumeMounts:
+            - mountPath: /bitnami/postgresql
+              name: heroes-db-data
+            - mountPath: /docker-entrypoint-initdb.d
+              name: heroes-db-init-data
+      initContainers:
+        - command:
+            - sh
+            - get-data.sh
+          image: registry.access.redhat.com/ubi8-minimal:8.6
+          name: get-data
+          volumeMounts:
+            - mountPath: /docker-entrypoint-preinitdb.d
+              name: heroes-db-init
+            - mountPath: /docker-entrypoint-initdb.d
+              name: heroes-db-init-data
+          workingDir: /docker-entrypoint-preinitdb.d
+      volumes:
+        - emptyDir: {}
+          name: heroes-db-data
+        - emptyDir: {}
+          name: heroes-db-init-data
+        - configMap:
+            name: heroes-db-init
+          name: heroes-db-init

--- a/rest-heroes/deploy/helm/minikube/rest-heroes-java11-latest-minikube/templates/secret.yaml
+++ b/rest-heroes/deploy/helm/minikube/rest-heroes-java11-latest-minikube/templates/secret.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: rest-heroes-config-creds
+data:
+  quarkus.datasource.username: c3VwZXJtYW4=
+  quarkus.datasource.password: c3VwZXJtYW4=
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: heroes-db-config
+data:
+  POSTGRESQL_DATABASE: aGVyb2VzX2RhdGFiYXNl
+  POSTGRESQL_USERNAME: c3VwZXJtYW4=
+  POSTGRESQL_PASSWORD: c3VwZXJtYW4=
+type: Opaque

--- a/rest-heroes/deploy/helm/minikube/rest-heroes-java11-latest-minikube/templates/service.yaml
+++ b/rest-heroes/deploy/helm/minikube/rest-heroes-java11-latest-minikube/templates/service.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: heroes-db
+spec:
+  ports:
+    - port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    name: heroes-db
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    app.quarkus.io/vcs-ref: main
+    app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "heroes-db,otel-collector"
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:46:26 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8083"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: rest-heroes
+    app.kubernetes.io/part-of: heroes-service
+    app.kubernetes.io/version: java11-latest
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: rest-heroes
+spec:
+  ports:
+    - name: http
+      nodePort: 30471
+      port: 80
+      protocol: TCP
+      targetPort: 8083
+  selector:
+    app.kubernetes.io/name: rest-heroes
+    app.kubernetes.io/part-of: heroes-service
+    app.kubernetes.io/version: java11-latest
+  type: {{ .Values.app.serviceType }}

--- a/rest-heroes/deploy/helm/minikube/rest-heroes-java11-latest-minikube/values.yaml
+++ b/rest-heroes/deploy/helm/minikube/rest-heroes-java11-latest-minikube/values.yaml
@@ -1,0 +1,24 @@
+---
+app:
+  serviceType: ClusterIP
+  livenessProbe:
+    failureThreshold: 3
+    periodSeconds: 10
+    timeoutSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/live
+      scheme: HTTP
+      port: 8083
+  image: quay.io/quarkus-super-heroes/rest-heroes:java11-latest
+  readinessProbe:
+    failureThreshold: 3
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/ready
+      scheme: HTTP
+      port: 8083

--- a/rest-heroes/deploy/helm/openshift/rest-heroes-java11-latest-openshift/Chart.yaml
+++ b/rest-heroes/deploy/helm/openshift/rest-heroes-java11-latest-openshift/Chart.yaml
@@ -1,0 +1,4 @@
+---
+name: rest-heroes-java11-latest-openshift
+version: 1.0.0
+apiVersion: v2

--- a/rest-heroes/deploy/helm/openshift/rest-heroes-java11-latest-openshift/templates/NOTES.txt
+++ b/rest-heroes/deploy/helm/openshift/rest-heroes-java11-latest-openshift/templates/NOTES.txt
@@ -1,0 +1,72 @@
+# Quarkus Helm Notes
+
+To access the Helm annotations or properties you just need to have the following dependency in your
+class path:
+
+    <dependency>
+        <groupId>io.quarkiverse.helm</groupId>
+        <artifactId>quarkus-helm</artifactId>
+        <version>{quarkus-helm-version}</version>
+    </dependency>
+
+Build the project using:
+
+    mvn clean package
+
+You can find the generated Helm artifacts under: `target/helm/kubernetes/<chart name>/` that should look like:
+- Chart.yaml
+- values.yaml
+- templates/*.yml the generated resources by Quarkus Helm
+
+**Note**: The `<chart name>` is set from either the property `quarkus.helm.name` or the `@HelmChart` annotation or the Quarkus application.
+
+# Requirements
+
+- Have installed [the Helm command line](https://helm.sh/docs/intro/install/)
+- Have connected/logged to a kubernetes cluster
+- Configure your Quarkus application to use any of the Quarkus Kubernetes extensions like Quarkus Kubernetes, Quarkus OpenShift or Quarkus Knative.
+- Configure your Quarkus application to use any of [the Quarkus Container Image extensions](https://quarkus.io/guides/container-image) - This example uses `container-image-docker`.
+
+# How can it be used?
+
+You can run the following Maven command in order to generate the Helm artifacts and build/push the image into a container registry:
+
+```shell
+mvn clean package -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=<your container registry> -Dquarkus.container-image.group=<your container registry namespace>
+```
+
+This command will push the image to a container registry and will become available when a pod or container is created.
+
+Finally, let's use Helm to deploy it into the cluster:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name>
+```
+
+The above command will deploy a chart using the default values (as defined within the `values.yaml` file). We can override the default values to use your `values.dev.yaml` file by executing the following command:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name> --values ./target/helm/<chart name>/kubernetes/values.dev.yaml
+```
+
+How can I update my deployment?
+
+- Via the `upgrade` option of Helm command line:
+
+After making changes to your project and regenerating the Helm resources and the application container image, then you need to upgrade your deployment:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name>
+```
+
+- Via the `set` option of Helm command line:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name> --set <app name>.replicas=1
+```
+
+How can we delete my deployment?
+
+```shell
+helm uninstall helm-example
+```

--- a/rest-heroes/deploy/helm/openshift/rest-heroes-java11-latest-openshift/templates/configmap.yaml
+++ b/rest-heroes/deploy/helm/openshift/rest-heroes-java11-latest-openshift/templates/configmap.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: rest-heroes-config
+data:
+  quarkus.hibernate-orm.database.generation: validate
+  quarkus.hibernate-orm.sql-load-script: no-file
+  quarkus.datasource.reactive.url: postgresql://heroes-db:5432/heroes_database
+  quarkus.opentelemetry.tracer.exporter.otlp.endpoint: http://otel-collector:4317
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: heroes-db-init
+data:
+  get-data.sh: |-
+    #!/bin/bash
+
+    curl https://raw.githubusercontent.com/quarkusio/quarkus-super-heroes/main/rest-heroes/deploy/db-init/initialize-tables.sql --output /docker-entrypoint-initdb.d/1-init-tables.sql

--- a/rest-heroes/deploy/helm/openshift/rest-heroes-java11-latest-openshift/templates/deployment.yaml
+++ b/rest-heroes/deploy/helm/openshift/rest-heroes-java11-latest-openshift/templates/deployment.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: heroes-service
+    app.openshift.io/runtime: postgresql
+  name: heroes-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: heroes-db
+  template:
+    metadata:
+      labels:
+        name: heroes-db
+        application: heroes-service
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - envFrom:
+            - secretRef:
+                name: heroes-db-config
+          image: bitnami/postgresql:14
+          name: heroes-db
+          ports:
+            - containerPort: 5432
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              memory: 32Mi
+          volumeMounts:
+            - mountPath: /bitnami/postgresql
+              name: heroes-db-data
+            - mountPath: /docker-entrypoint-initdb.d
+              name: heroes-db-init-data
+      initContainers:
+        - command:
+            - sh
+            - get-data.sh
+          image: registry.access.redhat.com/ubi8-minimal:8.6
+          name: get-data
+          volumeMounts:
+            - mountPath: /docker-entrypoint-preinitdb.d
+              name: heroes-db-init
+            - mountPath: /docker-entrypoint-initdb.d
+              name: heroes-db-init-data
+          workingDir: /docker-entrypoint-preinitdb.d
+      volumes:
+        - emptyDir: {}
+          name: heroes-db-data
+        - emptyDir: {}
+          name: heroes-db-init-data
+        - configMap:
+            name: heroes-db-init
+          name: heroes-db-init

--- a/rest-heroes/deploy/helm/openshift/rest-heroes-java11-latest-openshift/templates/deploymentconfig.yaml
+++ b/rest-heroes/deploy/helm/openshift/rest-heroes-java11-latest-openshift/templates/deploymentconfig.yaml
@@ -1,0 +1,102 @@
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  annotations:
+    app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "heroes-db,otel-collector"
+    app.openshift.io/vcs-ref: main
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:48:42 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8083"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: rest-heroes
+    app.kubernetes.io/part-of: heroes-service
+    app.kubernetes.io/version: java11-latest
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+    app.openshift.io/runtime: quarkus
+  name: rest-heroes
+spec:
+  replicas: 1
+  selector:
+    app.kubernetes.io/version: java11-latest
+    app.kubernetes.io/part-of: heroes-service
+    app.kubernetes.io/name: rest-heroes
+  template:
+    metadata:
+      annotations:
+        app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+        app.openshift.io/connects-to: "heroes-db,otel-collector"
+        app.openshift.io/vcs-ref: main
+        app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+        app.quarkus.io/build-timestamp: 2023-02-20 - 20:48:42 +0000
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /q/metrics
+        prometheus.io/port: "8083"
+        prometheus.io/scheme: http
+      labels:
+        app: rest-heroes
+        application: heroes-service
+        system: quarkus-super-heroes
+        app.openshift.io/runtime: quarkus
+        app.kubernetes.io/version: java11-latest
+        app.kubernetes.io/part-of: heroes-service
+        app.kubernetes.io/name: rest-heroes
+    spec:
+      containers:
+        - env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom:
+            - secretRef:
+                name: rest-heroes-config-creds
+            - configMapRef:
+                name: rest-heroes-config
+          image: {{ .Values.app.image }}
+          imagePullPolicy: Always
+          livenessProbe:
+            failureThreshold: {{ .Values.app.livenessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.livenessProbe.httpGet.path }}
+              port: {{ .Values.app.livenessProbe.httpGet.port }}
+              scheme: {{ .Values.app.livenessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.livenessProbe.timeoutSeconds }}
+          name: rest-heroes
+          ports:
+            - containerPort: 8083
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: {{ .Values.app.readinessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.readinessProbe.httpGet.path }}
+              port: {{ .Values.app.readinessProbe.httpGet.port }}
+              scheme: {{ .Values.app.readinessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.readinessProbe.timeoutSeconds }}
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 256Mi
+  triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+          - rest-heroes
+        from:
+          kind: ImageStreamTag
+          name: rest-heroes:java11-latest
+      type: ImageChange

--- a/rest-heroes/deploy/helm/openshift/rest-heroes-java11-latest-openshift/templates/imagestream.yaml
+++ b/rest-heroes/deploy/helm/openshift/rest-heroes-java11-latest-openshift/templates/imagestream.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  annotations:
+    app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "heroes-db,otel-collector"
+    app.openshift.io/vcs-ref: main
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:48:42 +0000
+  labels:
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+    app.openshift.io/runtime: quarkus
+    app.kubernetes.io/version: java11-latest
+    app.kubernetes.io/part-of: heroes-service
+    app.kubernetes.io/name: rest-heroes
+  name: rest-heroes
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+    - from:
+        kind: DockerImage
+        name: quay.io/quarkus-super-heroes/rest-heroes:java11-latest
+      importPolicy: {}
+      name: java11-latest
+      referencePolicy:
+        type: Source
+    - from:
+        kind: DockerImage
+        name: quay.io/quarkus-super-heroes/rest-heroes:java17-latest
+      importPolicy: {}
+      name: java17-latest
+      referencePolicy:
+        type: Source
+    - from:
+        kind: DockerImage
+        name: quay.io/quarkus-super-heroes/rest-heroes:native-latest
+      importPolicy: {}
+      name: native-latest
+      referencePolicy:
+        type: Source

--- a/rest-heroes/deploy/helm/openshift/rest-heroes-java11-latest-openshift/templates/route.yaml
+++ b/rest-heroes/deploy/helm/openshift/rest-heroes-java11-latest-openshift/templates/route.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  annotations:
+    app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "heroes-db,otel-collector"
+    app.openshift.io/vcs-ref: main
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:48:42 +0000
+  labels:
+    app.kubernetes.io/name: rest-heroes
+    app.kubernetes.io/part-of: heroes-service
+    app.kubernetes.io/version: java11-latest
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+    app.openshift.io/runtime: quarkus
+  name: rest-heroes
+spec:
+  port:
+    targetPort: http
+  to:
+    kind: Service
+    name: rest-heroes

--- a/rest-heroes/deploy/helm/openshift/rest-heroes-java11-latest-openshift/templates/secret.yaml
+++ b/rest-heroes/deploy/helm/openshift/rest-heroes-java11-latest-openshift/templates/secret.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: rest-heroes-config-creds
+data:
+  quarkus.datasource.username: c3VwZXJtYW4=
+  quarkus.datasource.password: c3VwZXJtYW4=
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: heroes-db-config
+data:
+  POSTGRESQL_DATABASE: aGVyb2VzX2RhdGFiYXNl
+  POSTGRESQL_USERNAME: c3VwZXJtYW4=
+  POSTGRESQL_PASSWORD: c3VwZXJtYW4=
+type: Opaque

--- a/rest-heroes/deploy/helm/openshift/rest-heroes-java11-latest-openshift/templates/service.yaml
+++ b/rest-heroes/deploy/helm/openshift/rest-heroes-java11-latest-openshift/templates/service.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: heroes-db
+    application: heroes-service
+    system: quarkus-super-heroes
+  name: heroes-db
+spec:
+  ports:
+    - port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    name: heroes-db
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "heroes-db,otel-collector"
+    app.openshift.io/vcs-ref: main
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:48:42 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8083"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: rest-heroes
+    app.kubernetes.io/part-of: heroes-service
+    app.kubernetes.io/version: java11-latest
+    app: rest-heroes
+    application: heroes-service
+    system: quarkus-super-heroes
+    app.openshift.io/runtime: quarkus
+  name: rest-heroes
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8083
+  selector:
+    app.kubernetes.io/name: rest-heroes
+    app.kubernetes.io/part-of: heroes-service
+    app.kubernetes.io/version: java11-latest
+  type: {{ .Values.app.serviceType }}

--- a/rest-heroes/deploy/helm/openshift/rest-heroes-java11-latest-openshift/values.yaml
+++ b/rest-heroes/deploy/helm/openshift/rest-heroes-java11-latest-openshift/values.yaml
@@ -1,0 +1,24 @@
+---
+app:
+  serviceType: ClusterIP
+  livenessProbe:
+    failureThreshold: 3
+    periodSeconds: 10
+    timeoutSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/live
+      scheme: HTTP
+      port: 8083
+  image: rest-heroes:java11-latest
+  readinessProbe:
+    failureThreshold: 3
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/ready
+      scheme: HTTP
+      port: 8083

--- a/rest-heroes/pom.xml
+++ b/rest-heroes/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.quarkus.workshop.super-heroes</groupId>
   <artifactId>rest-heroes</artifactId>
-  <version>1.0</version>
+  <version>java11-latest</version>
   <name>Quarkus Sample :: Super-Heroes :: Heroes Microservice</name>
   <properties>
     <assertj.version>3.24.2</assertj.version>
@@ -99,6 +99,11 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-opentelemetry</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkiverse.helm</groupId>
+      <artifactId>quarkus-helm</artifactId>
+      <version>0.2.5</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/rest-villains/deploy/helm/knative/rest-villains-java11-latest-knative/Chart.yaml
+++ b/rest-villains/deploy/helm/knative/rest-villains-java11-latest-knative/Chart.yaml
@@ -1,0 +1,4 @@
+---
+name: rest-villains-java11-latest-knative
+version: 1.0.0
+apiVersion: v2

--- a/rest-villains/deploy/helm/knative/rest-villains-java11-latest-knative/templates/NOTES.txt
+++ b/rest-villains/deploy/helm/knative/rest-villains-java11-latest-knative/templates/NOTES.txt
@@ -1,0 +1,72 @@
+# Quarkus Helm Notes
+
+To access the Helm annotations or properties you just need to have the following dependency in your
+class path:
+
+    <dependency>
+        <groupId>io.quarkiverse.helm</groupId>
+        <artifactId>quarkus-helm</artifactId>
+        <version>{quarkus-helm-version}</version>
+    </dependency>
+
+Build the project using:
+
+    mvn clean package
+
+You can find the generated Helm artifacts under: `target/helm/kubernetes/<chart name>/` that should look like:
+- Chart.yaml
+- values.yaml
+- templates/*.yml the generated resources by Quarkus Helm
+
+**Note**: The `<chart name>` is set from either the property `quarkus.helm.name` or the `@HelmChart` annotation or the Quarkus application.
+
+# Requirements
+
+- Have installed [the Helm command line](https://helm.sh/docs/intro/install/)
+- Have connected/logged to a kubernetes cluster
+- Configure your Quarkus application to use any of the Quarkus Kubernetes extensions like Quarkus Kubernetes, Quarkus OpenShift or Quarkus Knative.
+- Configure your Quarkus application to use any of [the Quarkus Container Image extensions](https://quarkus.io/guides/container-image) - This example uses `container-image-docker`.
+
+# How can it be used?
+
+You can run the following Maven command in order to generate the Helm artifacts and build/push the image into a container registry:
+
+```shell
+mvn clean package -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=<your container registry> -Dquarkus.container-image.group=<your container registry namespace>
+```
+
+This command will push the image to a container registry and will become available when a pod or container is created.
+
+Finally, let's use Helm to deploy it into the cluster:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name>
+```
+
+The above command will deploy a chart using the default values (as defined within the `values.yaml` file). We can override the default values to use your `values.dev.yaml` file by executing the following command:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name> --values ./target/helm/<chart name>/kubernetes/values.dev.yaml
+```
+
+How can I update my deployment?
+
+- Via the `upgrade` option of Helm command line:
+
+After making changes to your project and regenerating the Helm resources and the application container image, then you need to upgrade your deployment:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name>
+```
+
+- Via the `set` option of Helm command line:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name> --set <app name>.replicas=1
+```
+
+How can we delete my deployment?
+
+```shell
+helm uninstall helm-example
+```

--- a/rest-villains/deploy/helm/knative/rest-villains-java11-latest-knative/templates/configmap.yaml
+++ b/rest-villains/deploy/helm/knative/rest-villains-java11-latest-knative/templates/configmap.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+  name: rest-villains-config
+data:
+  quarkus.hibernate-orm.database.generation: validate
+  quarkus.hibernate-orm.sql-load-script: no-file
+  quarkus.datasource.jdbc.url: jdbc:otel:postgresql://villains-db:5432/villains_database
+  quarkus.opentelemetry.tracer.exporter.otlp.endpoint: http://otel-collector:4317
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+  name: villains-db-init
+data:
+  get-data.sh: |-
+    #!/bin/bash
+
+    curl https://raw.githubusercontent.com/quarkusio/quarkus-super-heroes/main/rest-villains/deploy/db-init/initialize-tables.sql --output /docker-entrypoint-initdb.d/1-init-tables.sql

--- a/rest-villains/deploy/helm/knative/rest-villains-java11-latest-knative/templates/deployment.yaml
+++ b/rest-villains/deploy/helm/knative/rest-villains-java11-latest-knative/templates/deployment.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: villains-service
+    app.openshift.io/runtime: postgresql
+  name: villains-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: villains-db
+  template:
+    metadata:
+      labels:
+        application: villains-service
+        name: villains-db
+    spec:
+      containers:
+        - envFrom:
+            - secretRef:
+                name: villains-db-config
+          image: bitnami/postgresql:14
+          name: villains-db
+          ports:
+            - containerPort: 5432
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              memory: 32Mi
+          volumeMounts:
+            - mountPath: /bitnami/postgresql
+              name: villains-db-data
+            - mountPath: /docker-entrypoint-initdb.d
+              name: villains-db-init-data
+      initContainers:
+        - command:
+            - sh
+            - get-data.sh
+          image: registry.access.redhat.com/ubi8-minimal:8.6
+          name: get-data
+          volumeMounts:
+            - mountPath: /docker-entrypoint-preinitdb.d
+              name: villains-db-init
+            - mountPath: /docker-entrypoint-initdb.d
+              name: villains-db-init-data
+          workingDir: /docker-entrypoint-preinitdb.d
+      volumes:
+        - emptyDir: {}
+          name: villains-db-data
+        - emptyDir: {}
+          name: villains-db-init-data
+        - configMap:
+            name: villains-db-init
+          name: villains-db-init

--- a/rest-villains/deploy/helm/knative/rest-villains-java11-latest-knative/templates/secret.yaml
+++ b/rest-villains/deploy/helm/knative/rest-villains-java11-latest-knative/templates/secret.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+  name: rest-villains-config-creds
+data:
+  quarkus.datasource.username: c3VwZXJiYWQ=
+  quarkus.datasource.password: c3VwZXJiYWQ=
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+  name: villains-db-config
+data:
+  POSTGRESQL_DATABASE: dmlsbGFpbnNfZGF0YWJhc2U=
+  POSTGRESQL_USERNAME: c3VwZXJiYWQ=
+  POSTGRESQL_PASSWORD: c3VwZXJiYWQ=
+type: Opaque

--- a/rest-villains/deploy/helm/knative/rest-villains-java11-latest-knative/templates/service.yaml
+++ b/rest-villains/deploy/helm/knative/rest-villains-java11-latest-knative/templates/service.yaml
@@ -1,0 +1,81 @@
+---
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  annotations:
+    app.openshift.io/connects-to: "villains-db,otel-collector"
+    app.openshift.io/vcs-ref: main
+    app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:50:18 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8084"
+    prometheus.io/scheme: http
+  labels:
+    app: rest-villains
+    app.openshift.io/runtime: quarkus
+    application: villains-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/version: java11-latest
+    app.kubernetes.io/name: rest-villains
+    app.kubernetes.io/part-of: villains-service
+  name: rest-villains
+spec:
+  template:
+    spec:
+      containers:
+        - envFrom:
+            - secretRef:
+                name: rest-villains-config-creds
+            - configMapRef:
+                name: rest-villains-config
+          image: {{ .Values.app.image }}
+          imagePullPolicy: Always
+          livenessProbe:
+            failureThreshold: {{ .Values.app.livenessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.livenessProbe.httpGet.path }}
+              port: {{ .Values.app.livenessProbe.httpGet.port }}
+              scheme: {{ .Values.app.livenessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.livenessProbe.timeoutSeconds }}
+          name: rest-villains
+          ports:
+            - containerPort: 8084
+              name: http1
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: {{ .Values.app.readinessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.readinessProbe.httpGet.path }}
+              port: {{ .Values.app.readinessProbe.httpGet.port }}
+              scheme: {{ .Values.app.readinessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.readinessProbe.timeoutSeconds }}
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+  name: villains-db
+spec:
+  ports:
+    - port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    name: villains-db
+  type: ClusterIP

--- a/rest-villains/deploy/helm/knative/rest-villains-java11-latest-knative/values.yaml
+++ b/rest-villains/deploy/helm/knative/rest-villains-java11-latest-knative/values.yaml
@@ -1,0 +1,24 @@
+---
+app:
+  serviceType: ClusterIP
+  livenessProbe:
+    failureThreshold: 3
+    periodSeconds: 10
+    timeoutSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/live
+      scheme: HTTP
+      port: ":START:{{ .Values.app.livenessProbe.httpGet.port }}:END:"
+  image: rest-villains:java11-latest
+  readinessProbe:
+    failureThreshold: 3
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/ready
+      scheme: HTTP
+      port: ":START:{{ .Values.app.readinessProbe.httpGet.port }}:END:"

--- a/rest-villains/deploy/helm/kubernetes/rest-villains-java11-latest-kubernetes/Chart.yaml
+++ b/rest-villains/deploy/helm/kubernetes/rest-villains-java11-latest-kubernetes/Chart.yaml
@@ -1,0 +1,4 @@
+---
+name: rest-villains-java11-latest-kubernetes
+version: 1.0.0
+apiVersion: v2

--- a/rest-villains/deploy/helm/kubernetes/rest-villains-java11-latest-kubernetes/templates/NOTES.txt
+++ b/rest-villains/deploy/helm/kubernetes/rest-villains-java11-latest-kubernetes/templates/NOTES.txt
@@ -1,0 +1,72 @@
+# Quarkus Helm Notes
+
+To access the Helm annotations or properties you just need to have the following dependency in your
+class path:
+
+    <dependency>
+        <groupId>io.quarkiverse.helm</groupId>
+        <artifactId>quarkus-helm</artifactId>
+        <version>{quarkus-helm-version}</version>
+    </dependency>
+
+Build the project using:
+
+    mvn clean package
+
+You can find the generated Helm artifacts under: `target/helm/kubernetes/<chart name>/` that should look like:
+- Chart.yaml
+- values.yaml
+- templates/*.yml the generated resources by Quarkus Helm
+
+**Note**: The `<chart name>` is set from either the property `quarkus.helm.name` or the `@HelmChart` annotation or the Quarkus application.
+
+# Requirements
+
+- Have installed [the Helm command line](https://helm.sh/docs/intro/install/)
+- Have connected/logged to a kubernetes cluster
+- Configure your Quarkus application to use any of the Quarkus Kubernetes extensions like Quarkus Kubernetes, Quarkus OpenShift or Quarkus Knative.
+- Configure your Quarkus application to use any of [the Quarkus Container Image extensions](https://quarkus.io/guides/container-image) - This example uses `container-image-docker`.
+
+# How can it be used?
+
+You can run the following Maven command in order to generate the Helm artifacts and build/push the image into a container registry:
+
+```shell
+mvn clean package -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=<your container registry> -Dquarkus.container-image.group=<your container registry namespace>
+```
+
+This command will push the image to a container registry and will become available when a pod or container is created.
+
+Finally, let's use Helm to deploy it into the cluster:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name>
+```
+
+The above command will deploy a chart using the default values (as defined within the `values.yaml` file). We can override the default values to use your `values.dev.yaml` file by executing the following command:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name> --values ./target/helm/<chart name>/kubernetes/values.dev.yaml
+```
+
+How can I update my deployment?
+
+- Via the `upgrade` option of Helm command line:
+
+After making changes to your project and regenerating the Helm resources and the application container image, then you need to upgrade your deployment:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name>
+```
+
+- Via the `set` option of Helm command line:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name> --set <app name>.replicas=1
+```
+
+How can we delete my deployment?
+
+```shell
+helm uninstall helm-example
+```

--- a/rest-villains/deploy/helm/kubernetes/rest-villains-java11-latest-kubernetes/templates/configmap.yaml
+++ b/rest-villains/deploy/helm/kubernetes/rest-villains-java11-latest-kubernetes/templates/configmap.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+  name: rest-villains-config
+data:
+  quarkus.hibernate-orm.database.generation: validate
+  quarkus.hibernate-orm.sql-load-script: no-file
+  quarkus.datasource.jdbc.url: jdbc:otel:postgresql://villains-db:5432/villains_database
+  quarkus.opentelemetry.tracer.exporter.otlp.endpoint: http://otel-collector:4317
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+  name: villains-db-init
+data:
+  get-data.sh: |-
+    #!/bin/bash
+
+    curl https://raw.githubusercontent.com/quarkusio/quarkus-super-heroes/main/rest-villains/deploy/db-init/initialize-tables.sql --output /docker-entrypoint-initdb.d/1-init-tables.sql

--- a/rest-villains/deploy/helm/kubernetes/rest-villains-java11-latest-kubernetes/templates/deployment.yaml
+++ b/rest-villains/deploy/helm/kubernetes/rest-villains-java11-latest-kubernetes/templates/deployment.yaml
@@ -1,0 +1,152 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    app.openshift.io/connects-to: "villains-db,otel-collector"
+    app.quarkus.io/vcs-ref: main
+    app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:43:10 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8084"
+    prometheus.io/scheme: http
+  labels:
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/version: java11-latest
+    app.kubernetes.io/part-of: villains-service
+    app.kubernetes.io/name: rest-villains
+  name: rest-villains
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/version: java11-latest
+      app.kubernetes.io/part-of: villains-service
+      app.kubernetes.io/name: rest-villains
+  template:
+    metadata:
+      annotations:
+        app.openshift.io/connects-to: "villains-db,otel-collector"
+        app.quarkus.io/vcs-ref: main
+        app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+        app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+        app.quarkus.io/build-timestamp: 2023-02-20 - 20:43:10 +0000
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /q/metrics
+        prometheus.io/port: "8084"
+        prometheus.io/scheme: http
+      labels:
+        app: rest-villains
+        application: villains-service
+        system: quarkus-super-heroes
+        app.kubernetes.io/version: java11-latest
+        app.kubernetes.io/part-of: villains-service
+        app.kubernetes.io/name: rest-villains
+    spec:
+      containers:
+        - env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom:
+            - configMapRef:
+                name: rest-villains-config
+            - secretRef:
+                name: rest-villains-config-creds
+          image: {{ .Values.app.image }}
+          imagePullPolicy: Always
+          livenessProbe:
+            failureThreshold: {{ .Values.app.livenessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.livenessProbe.httpGet.path }}
+              port: {{ .Values.app.livenessProbe.httpGet.port }}
+              scheme: {{ .Values.app.livenessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.livenessProbe.timeoutSeconds }}
+          name: rest-villains
+          ports:
+            - containerPort: 8084
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: {{ .Values.app.readinessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.readinessProbe.httpGet.path }}
+              port: {{ .Values.app.readinessProbe.httpGet.port }}
+              scheme: {{ .Values.app.readinessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.readinessProbe.timeoutSeconds }}
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 256Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: villains-service
+    app.openshift.io/runtime: postgresql
+  name: villains-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: villains-db
+  template:
+    metadata:
+      labels:
+        application: villains-service
+        name: villains-db
+    spec:
+      containers:
+        - envFrom:
+            - secretRef:
+                name: villains-db-config
+          image: bitnami/postgresql:14
+          name: villains-db
+          ports:
+            - containerPort: 5432
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              memory: 32Mi
+          volumeMounts:
+            - mountPath: /bitnami/postgresql
+              name: villains-db-data
+            - mountPath: /docker-entrypoint-initdb.d
+              name: villains-db-init-data
+      initContainers:
+        - command:
+            - sh
+            - get-data.sh
+          image: registry.access.redhat.com/ubi8-minimal:8.6
+          name: get-data
+          volumeMounts:
+            - mountPath: /docker-entrypoint-preinitdb.d
+              name: villains-db-init
+            - mountPath: /docker-entrypoint-initdb.d
+              name: villains-db-init-data
+          workingDir: /docker-entrypoint-preinitdb.d
+      volumes:
+        - emptyDir: {}
+          name: villains-db-data
+        - emptyDir: {}
+          name: villains-db-init-data
+        - configMap:
+            name: villains-db-init
+          name: villains-db-init

--- a/rest-villains/deploy/helm/kubernetes/rest-villains-java11-latest-kubernetes/templates/secret.yaml
+++ b/rest-villains/deploy/helm/kubernetes/rest-villains-java11-latest-kubernetes/templates/secret.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+  name: rest-villains-config-creds
+data:
+  quarkus.datasource.username: c3VwZXJiYWQ=
+  quarkus.datasource.password: c3VwZXJiYWQ=
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+  name: villains-db-config
+data:
+  POSTGRESQL_DATABASE: dmlsbGFpbnNfZGF0YWJhc2U=
+  POSTGRESQL_USERNAME: c3VwZXJiYWQ=
+  POSTGRESQL_PASSWORD: c3VwZXJiYWQ=
+type: Opaque

--- a/rest-villains/deploy/helm/kubernetes/rest-villains-java11-latest-kubernetes/templates/service.yaml
+++ b/rest-villains/deploy/helm/kubernetes/rest-villains-java11-latest-kubernetes/templates/service.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+  name: villains-db
+spec:
+  ports:
+    - port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    name: villains-db
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    app.openshift.io/connects-to: "villains-db,otel-collector"
+    app.quarkus.io/vcs-ref: main
+    app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:43:10 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8084"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: rest-villains
+    app.kubernetes.io/part-of: villains-service
+    app.kubernetes.io/version: java11-latest
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+  name: rest-villains
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8084
+  selector:
+    app.kubernetes.io/name: rest-villains
+    app.kubernetes.io/part-of: villains-service
+    app.kubernetes.io/version: java11-latest
+  type: {{ .Values.app.serviceType }}

--- a/rest-villains/deploy/helm/kubernetes/rest-villains-java11-latest-kubernetes/values.yaml
+++ b/rest-villains/deploy/helm/kubernetes/rest-villains-java11-latest-kubernetes/values.yaml
@@ -1,0 +1,24 @@
+---
+app:
+  serviceType: ClusterIP
+  livenessProbe:
+    failureThreshold: 3
+    periodSeconds: 10
+    timeoutSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/live
+      scheme: HTTP
+      port: 8084
+  image: quay.io/quarkus-super-heroes/rest-villains:java11-latest
+  readinessProbe:
+    failureThreshold: 3
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/ready
+      scheme: HTTP
+      port: 8084

--- a/rest-villains/deploy/helm/minikube/rest-villains-java11-latest-minikube/Chart.yaml
+++ b/rest-villains/deploy/helm/minikube/rest-villains-java11-latest-minikube/Chart.yaml
@@ -1,0 +1,4 @@
+---
+name: rest-villains-java11-latest-minikube
+version: 1.0.0
+apiVersion: v2

--- a/rest-villains/deploy/helm/minikube/rest-villains-java11-latest-minikube/templates/NOTES.txt
+++ b/rest-villains/deploy/helm/minikube/rest-villains-java11-latest-minikube/templates/NOTES.txt
@@ -1,0 +1,72 @@
+# Quarkus Helm Notes
+
+To access the Helm annotations or properties you just need to have the following dependency in your
+class path:
+
+    <dependency>
+        <groupId>io.quarkiverse.helm</groupId>
+        <artifactId>quarkus-helm</artifactId>
+        <version>{quarkus-helm-version}</version>
+    </dependency>
+
+Build the project using:
+
+    mvn clean package
+
+You can find the generated Helm artifacts under: `target/helm/kubernetes/<chart name>/` that should look like:
+- Chart.yaml
+- values.yaml
+- templates/*.yml the generated resources by Quarkus Helm
+
+**Note**: The `<chart name>` is set from either the property `quarkus.helm.name` or the `@HelmChart` annotation or the Quarkus application.
+
+# Requirements
+
+- Have installed [the Helm command line](https://helm.sh/docs/intro/install/)
+- Have connected/logged to a kubernetes cluster
+- Configure your Quarkus application to use any of the Quarkus Kubernetes extensions like Quarkus Kubernetes, Quarkus OpenShift or Quarkus Knative.
+- Configure your Quarkus application to use any of [the Quarkus Container Image extensions](https://quarkus.io/guides/container-image) - This example uses `container-image-docker`.
+
+# How can it be used?
+
+You can run the following Maven command in order to generate the Helm artifacts and build/push the image into a container registry:
+
+```shell
+mvn clean package -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=<your container registry> -Dquarkus.container-image.group=<your container registry namespace>
+```
+
+This command will push the image to a container registry and will become available when a pod or container is created.
+
+Finally, let's use Helm to deploy it into the cluster:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name>
+```
+
+The above command will deploy a chart using the default values (as defined within the `values.yaml` file). We can override the default values to use your `values.dev.yaml` file by executing the following command:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name> --values ./target/helm/<chart name>/kubernetes/values.dev.yaml
+```
+
+How can I update my deployment?
+
+- Via the `upgrade` option of Helm command line:
+
+After making changes to your project and regenerating the Helm resources and the application container image, then you need to upgrade your deployment:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name>
+```
+
+- Via the `set` option of Helm command line:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name> --set <app name>.replicas=1
+```
+
+How can we delete my deployment?
+
+```shell
+helm uninstall helm-example
+```

--- a/rest-villains/deploy/helm/minikube/rest-villains-java11-latest-minikube/templates/configmap.yaml
+++ b/rest-villains/deploy/helm/minikube/rest-villains-java11-latest-minikube/templates/configmap.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+  name: rest-villains-config
+data:
+  quarkus.hibernate-orm.database.generation: validate
+  quarkus.hibernate-orm.sql-load-script: no-file
+  quarkus.datasource.jdbc.url: jdbc:otel:postgresql://villains-db:5432/villains_database
+  quarkus.opentelemetry.tracer.exporter.otlp.endpoint: http://otel-collector:4317
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+  name: villains-db-init
+data:
+  get-data.sh: |-
+    #!/bin/bash
+
+    curl https://raw.githubusercontent.com/quarkusio/quarkus-super-heroes/main/rest-villains/deploy/db-init/initialize-tables.sql --output /docker-entrypoint-initdb.d/1-init-tables.sql

--- a/rest-villains/deploy/helm/minikube/rest-villains-java11-latest-minikube/templates/deployment.yaml
+++ b/rest-villains/deploy/helm/minikube/rest-villains-java11-latest-minikube/templates/deployment.yaml
@@ -1,0 +1,152 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    app.quarkus.io/vcs-ref: main
+    app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "villains-db,otel-collector"
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:45:53 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8084"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: rest-villains
+    app.kubernetes.io/part-of: villains-service
+    app.kubernetes.io/version: java11-latest
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+  name: rest-villains
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: rest-villains
+      app.kubernetes.io/part-of: villains-service
+      app.kubernetes.io/version: java11-latest
+  template:
+    metadata:
+      annotations:
+        app.quarkus.io/vcs-ref: main
+        app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+        app.openshift.io/connects-to: "villains-db,otel-collector"
+        app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+        app.quarkus.io/build-timestamp: 2023-02-20 - 20:45:53 +0000
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /q/metrics
+        prometheus.io/port: "8084"
+        prometheus.io/scheme: http
+      labels:
+        app.kubernetes.io/name: rest-villains
+        app.kubernetes.io/part-of: villains-service
+        app.kubernetes.io/version: java11-latest
+        app: rest-villains
+        application: villains-service
+        system: quarkus-super-heroes
+    spec:
+      containers:
+        - env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom:
+            - configMapRef:
+                name: rest-villains-config
+            - secretRef:
+                name: rest-villains-config-creds
+          image: {{ .Values.app.image }}
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: {{ .Values.app.livenessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.livenessProbe.httpGet.path }}
+              port: {{ .Values.app.livenessProbe.httpGet.port }}
+              scheme: {{ .Values.app.livenessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.livenessProbe.timeoutSeconds }}
+          name: rest-villains
+          ports:
+            - containerPort: 8084
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: {{ .Values.app.readinessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.readinessProbe.httpGet.path }}
+              port: {{ .Values.app.readinessProbe.httpGet.port }}
+              scheme: {{ .Values.app.readinessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.readinessProbe.timeoutSeconds }}
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 256Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: villains-service
+    app.openshift.io/runtime: postgresql
+  name: villains-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: villains-db
+  template:
+    metadata:
+      labels:
+        application: villains-service
+        name: villains-db
+    spec:
+      containers:
+        - envFrom:
+            - secretRef:
+                name: villains-db-config
+          image: bitnami/postgresql:14
+          name: villains-db
+          ports:
+            - containerPort: 5432
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              memory: 32Mi
+          volumeMounts:
+            - mountPath: /bitnami/postgresql
+              name: villains-db-data
+            - mountPath: /docker-entrypoint-initdb.d
+              name: villains-db-init-data
+      initContainers:
+        - command:
+            - sh
+            - get-data.sh
+          image: registry.access.redhat.com/ubi8-minimal:8.6
+          name: get-data
+          volumeMounts:
+            - mountPath: /docker-entrypoint-preinitdb.d
+              name: villains-db-init
+            - mountPath: /docker-entrypoint-initdb.d
+              name: villains-db-init-data
+          workingDir: /docker-entrypoint-preinitdb.d
+      volumes:
+        - emptyDir: {}
+          name: villains-db-data
+        - emptyDir: {}
+          name: villains-db-init-data
+        - configMap:
+            name: villains-db-init
+          name: villains-db-init

--- a/rest-villains/deploy/helm/minikube/rest-villains-java11-latest-minikube/templates/secret.yaml
+++ b/rest-villains/deploy/helm/minikube/rest-villains-java11-latest-minikube/templates/secret.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+  name: rest-villains-config-creds
+data:
+  quarkus.datasource.username: c3VwZXJiYWQ=
+  quarkus.datasource.password: c3VwZXJiYWQ=
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+  name: villains-db-config
+data:
+  POSTGRESQL_DATABASE: dmlsbGFpbnNfZGF0YWJhc2U=
+  POSTGRESQL_USERNAME: c3VwZXJiYWQ=
+  POSTGRESQL_PASSWORD: c3VwZXJiYWQ=
+type: Opaque

--- a/rest-villains/deploy/helm/minikube/rest-villains-java11-latest-minikube/templates/service.yaml
+++ b/rest-villains/deploy/helm/minikube/rest-villains-java11-latest-minikube/templates/service.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+  name: villains-db
+spec:
+  ports:
+    - port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    name: villains-db
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    app.quarkus.io/vcs-ref: main
+    app.quarkus.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "villains-db,otel-collector"
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:45:53 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8084"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: rest-villains
+    app.kubernetes.io/part-of: villains-service
+    app.kubernetes.io/version: java11-latest
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+  name: rest-villains
+spec:
+  ports:
+    - name: http
+      nodePort: 30526
+      port: 80
+      protocol: TCP
+      targetPort: 8084
+  selector:
+    app.kubernetes.io/name: rest-villains
+    app.kubernetes.io/part-of: villains-service
+    app.kubernetes.io/version: java11-latest
+  type: {{ .Values.app.serviceType }}

--- a/rest-villains/deploy/helm/minikube/rest-villains-java11-latest-minikube/values.yaml
+++ b/rest-villains/deploy/helm/minikube/rest-villains-java11-latest-minikube/values.yaml
@@ -1,0 +1,24 @@
+---
+app:
+  serviceType: ClusterIP
+  livenessProbe:
+    failureThreshold: 3
+    periodSeconds: 10
+    timeoutSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/live
+      scheme: HTTP
+      port: 8084
+  image: rest-villains:java11-latest
+  readinessProbe:
+    failureThreshold: 3
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/ready
+      scheme: HTTP
+      port: 8084

--- a/rest-villains/deploy/helm/openshift/rest-villains-java11-latest-openshift/Chart.yaml
+++ b/rest-villains/deploy/helm/openshift/rest-villains-java11-latest-openshift/Chart.yaml
@@ -1,0 +1,4 @@
+---
+name: rest-villains-java11-latest-openshift
+version: 1.0.0
+apiVersion: v2

--- a/rest-villains/deploy/helm/openshift/rest-villains-java11-latest-openshift/templates/NOTES.txt
+++ b/rest-villains/deploy/helm/openshift/rest-villains-java11-latest-openshift/templates/NOTES.txt
@@ -1,0 +1,72 @@
+# Quarkus Helm Notes
+
+To access the Helm annotations or properties you just need to have the following dependency in your
+class path:
+
+    <dependency>
+        <groupId>io.quarkiverse.helm</groupId>
+        <artifactId>quarkus-helm</artifactId>
+        <version>{quarkus-helm-version}</version>
+    </dependency>
+
+Build the project using:
+
+    mvn clean package
+
+You can find the generated Helm artifacts under: `target/helm/kubernetes/<chart name>/` that should look like:
+- Chart.yaml
+- values.yaml
+- templates/*.yml the generated resources by Quarkus Helm
+
+**Note**: The `<chart name>` is set from either the property `quarkus.helm.name` or the `@HelmChart` annotation or the Quarkus application.
+
+# Requirements
+
+- Have installed [the Helm command line](https://helm.sh/docs/intro/install/)
+- Have connected/logged to a kubernetes cluster
+- Configure your Quarkus application to use any of the Quarkus Kubernetes extensions like Quarkus Kubernetes, Quarkus OpenShift or Quarkus Knative.
+- Configure your Quarkus application to use any of [the Quarkus Container Image extensions](https://quarkus.io/guides/container-image) - This example uses `container-image-docker`.
+
+# How can it be used?
+
+You can run the following Maven command in order to generate the Helm artifacts and build/push the image into a container registry:
+
+```shell
+mvn clean package -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=<your container registry> -Dquarkus.container-image.group=<your container registry namespace>
+```
+
+This command will push the image to a container registry and will become available when a pod or container is created.
+
+Finally, let's use Helm to deploy it into the cluster:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name>
+```
+
+The above command will deploy a chart using the default values (as defined within the `values.yaml` file). We can override the default values to use your `values.dev.yaml` file by executing the following command:
+
+```shell
+helm install helm-example ./target/helm/kubernetes/<chart name> --values ./target/helm/<chart name>/kubernetes/values.dev.yaml
+```
+
+How can I update my deployment?
+
+- Via the `upgrade` option of Helm command line:
+
+After making changes to your project and regenerating the Helm resources and the application container image, then you need to upgrade your deployment:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name>
+```
+
+- Via the `set` option of Helm command line:
+
+```shell
+helm upgrade helm-example ./target/helm/kubernetes/<chart name> --set <app name>.replicas=1
+```
+
+How can we delete my deployment?
+
+```shell
+helm uninstall helm-example
+```

--- a/rest-villains/deploy/helm/openshift/rest-villains-java11-latest-openshift/templates/configmap.yaml
+++ b/rest-villains/deploy/helm/openshift/rest-villains-java11-latest-openshift/templates/configmap.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+  name: rest-villains-config
+data:
+  quarkus.hibernate-orm.database.generation: validate
+  quarkus.hibernate-orm.sql-load-script: no-file
+  quarkus.datasource.jdbc.url: jdbc:otel:postgresql://villains-db:5432/villains_database
+  quarkus.opentelemetry.tracer.exporter.otlp.endpoint: http://otel-collector:4317
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+  name: villains-db-init
+data:
+  get-data.sh: |-
+    #!/bin/bash
+
+    curl https://raw.githubusercontent.com/quarkusio/quarkus-super-heroes/main/rest-villains/deploy/db-init/initialize-tables.sql --output /docker-entrypoint-initdb.d/1-init-tables.sql

--- a/rest-villains/deploy/helm/openshift/rest-villains-java11-latest-openshift/templates/deployment.yaml
+++ b/rest-villains/deploy/helm/openshift/rest-villains-java11-latest-openshift/templates/deployment.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+    app.kubernetes.io/part-of: villains-service
+    app.openshift.io/runtime: postgresql
+  name: villains-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: villains-db
+  template:
+    metadata:
+      labels:
+        application: villains-service
+        name: villains-db
+    spec:
+      containers:
+        - envFrom:
+            - secretRef:
+                name: villains-db-config
+          image: bitnami/postgresql:14
+          name: villains-db
+          ports:
+            - containerPort: 5432
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              memory: 32Mi
+          volumeMounts:
+            - mountPath: /bitnami/postgresql
+              name: villains-db-data
+            - mountPath: /docker-entrypoint-initdb.d
+              name: villains-db-init-data
+      initContainers:
+        - command:
+            - sh
+            - get-data.sh
+          image: registry.access.redhat.com/ubi8-minimal:8.6
+          name: get-data
+          volumeMounts:
+            - mountPath: /docker-entrypoint-preinitdb.d
+              name: villains-db-init
+            - mountPath: /docker-entrypoint-initdb.d
+              name: villains-db-init-data
+          workingDir: /docker-entrypoint-preinitdb.d
+      volumes:
+        - emptyDir: {}
+          name: villains-db-data
+        - emptyDir: {}
+          name: villains-db-init-data
+        - configMap:
+            name: villains-db-init
+          name: villains-db-init

--- a/rest-villains/deploy/helm/openshift/rest-villains-java11-latest-openshift/templates/deploymentconfig.yaml
+++ b/rest-villains/deploy/helm/openshift/rest-villains-java11-latest-openshift/templates/deploymentconfig.yaml
@@ -1,0 +1,102 @@
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  annotations:
+    app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "villains-db,otel-collector"
+    app.openshift.io/vcs-ref: main
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:48:10 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8084"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: rest-villains
+    app.kubernetes.io/part-of: villains-service
+    app.kubernetes.io/version: java11-latest
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+    app.openshift.io/runtime: quarkus
+  name: rest-villains
+spec:
+  replicas: 1
+  selector:
+    app.kubernetes.io/part-of: villains-service
+    app.kubernetes.io/version: java11-latest
+    app.kubernetes.io/name: rest-villains
+  template:
+    metadata:
+      annotations:
+        app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+        app.openshift.io/connects-to: "villains-db,otel-collector"
+        app.openshift.io/vcs-ref: main
+        app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+        app.quarkus.io/build-timestamp: 2023-02-20 - 20:48:10 +0000
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /q/metrics
+        prometheus.io/port: "8084"
+        prometheus.io/scheme: http
+      labels:
+        app: rest-villains
+        application: villains-service
+        system: quarkus-super-heroes
+        app.openshift.io/runtime: quarkus
+        app.kubernetes.io/part-of: villains-service
+        app.kubernetes.io/version: java11-latest
+        app.kubernetes.io/name: rest-villains
+    spec:
+      containers:
+        - env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom:
+            - secretRef:
+                name: rest-villains-config-creds
+            - configMapRef:
+                name: rest-villains-config
+          image: {{ .Values.app.image }}
+          imagePullPolicy: Always
+          livenessProbe:
+            failureThreshold: {{ .Values.app.livenessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.livenessProbe.httpGet.path }}
+              port: {{ .Values.app.livenessProbe.httpGet.port }}
+              scheme: {{ .Values.app.livenessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.livenessProbe.timeoutSeconds }}
+          name: rest-villains
+          ports:
+            - containerPort: 8084
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: {{ .Values.app.readinessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.app.readinessProbe.httpGet.path }}
+              port: {{ .Values.app.readinessProbe.httpGet.port }}
+              scheme: {{ .Values.app.readinessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.app.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.app.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.app.readinessProbe.timeoutSeconds }}
+          resources:
+            limits:
+              memory: 768Mi
+            requests:
+              memory: 256Mi
+  triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+          - rest-villains
+        from:
+          kind: ImageStreamTag
+          name: rest-villains:java11-latest
+      type: ImageChange

--- a/rest-villains/deploy/helm/openshift/rest-villains-java11-latest-openshift/templates/imagestream.yaml
+++ b/rest-villains/deploy/helm/openshift/rest-villains-java11-latest-openshift/templates/imagestream.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  annotations:
+    app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "villains-db,otel-collector"
+    app.openshift.io/vcs-ref: main
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:48:10 +0000
+  labels:
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+    app.openshift.io/runtime: quarkus
+    app.kubernetes.io/part-of: villains-service
+    app.kubernetes.io/version: java11-latest
+    app.kubernetes.io/name: rest-villains
+  name: rest-villains
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+    - from:
+        kind: DockerImage
+        name: quay.io/quarkus-super-heroes/rest-villains:java11-latest
+      importPolicy: {}
+      name: java11-latest
+      referencePolicy:
+        type: Source
+    - from:
+        kind: DockerImage
+        name: quay.io/quarkus-super-heroes/rest-villains:java17-latest
+      importPolicy: {}
+      name: java17-latest
+      referencePolicy:
+        type: Source
+    - from:
+        kind: DockerImage
+        name: quay.io/quarkus-super-heroes/rest-villains:native-latest
+      importPolicy: {}
+      name: native-latest
+      referencePolicy:
+        type: Source

--- a/rest-villains/deploy/helm/openshift/rest-villains-java11-latest-openshift/templates/route.yaml
+++ b/rest-villains/deploy/helm/openshift/rest-villains-java11-latest-openshift/templates/route.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  annotations:
+    app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "villains-db,otel-collector"
+    app.openshift.io/vcs-ref: main
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:48:10 +0000
+  labels:
+    app.kubernetes.io/name: rest-villains
+    app.kubernetes.io/part-of: villains-service
+    app.kubernetes.io/version: java11-latest
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+    app.openshift.io/runtime: quarkus
+  name: rest-villains
+spec:
+  port:
+    targetPort: http
+  to:
+    kind: Service
+    name: rest-villains

--- a/rest-villains/deploy/helm/openshift/rest-villains-java11-latest-openshift/templates/secret.yaml
+++ b/rest-villains/deploy/helm/openshift/rest-villains-java11-latest-openshift/templates/secret.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+  name: rest-villains-config-creds
+data:
+  quarkus.datasource.username: c3VwZXJiYWQ=
+  quarkus.datasource.password: c3VwZXJiYWQ=
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+  name: villains-db-config
+data:
+  POSTGRESQL_DATABASE: dmlsbGFpbnNfZGF0YWJhc2U=
+  POSTGRESQL_USERNAME: c3VwZXJiYWQ=
+  POSTGRESQL_PASSWORD: c3VwZXJiYWQ=
+type: Opaque

--- a/rest-villains/deploy/helm/openshift/rest-villains-java11-latest-openshift/templates/service.yaml
+++ b/rest-villains/deploy/helm/openshift/rest-villains-java11-latest-openshift/templates/service.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: villains-db
+    application: villains-service
+    system: quarkus-super-heroes
+  name: villains-db
+spec:
+  ports:
+    - port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    name: villains-db
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    app.openshift.io/vcs-url: https://github.com/quarkusio/quarkus-super-heroes
+    app.openshift.io/connects-to: "villains-db,otel-collector"
+    app.openshift.io/vcs-ref: main
+    app.quarkus.io/commit-id: e6b908a2aad15d5f15e203fc2a7e40dd28e85bab
+    app.quarkus.io/build-timestamp: 2023-02-20 - 20:48:10 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8084"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: rest-villains
+    app.kubernetes.io/part-of: villains-service
+    app.kubernetes.io/version: java11-latest
+    app: rest-villains
+    application: villains-service
+    system: quarkus-super-heroes
+    app.openshift.io/runtime: quarkus
+  name: rest-villains
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8084
+  selector:
+    app.kubernetes.io/name: rest-villains
+    app.kubernetes.io/part-of: villains-service
+    app.kubernetes.io/version: java11-latest
+  type: {{ .Values.app.serviceType }}

--- a/rest-villains/deploy/helm/openshift/rest-villains-java11-latest-openshift/values.yaml
+++ b/rest-villains/deploy/helm/openshift/rest-villains-java11-latest-openshift/values.yaml
@@ -1,0 +1,24 @@
+---
+app:
+  serviceType: ClusterIP
+  livenessProbe:
+    failureThreshold: 3
+    periodSeconds: 10
+    timeoutSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/live
+      scheme: HTTP
+      port: 8084
+  image: rest-villains:java11-latest
+  readinessProbe:
+    failureThreshold: 3
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    initialDelaySeconds: 5
+    httpGet:
+      path: /q/health/ready
+      scheme: HTTP
+      port: 8084

--- a/rest-villains/pom.xml
+++ b/rest-villains/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.quarkus.sample.super-heroes</groupId>
   <artifactId>rest-villains</artifactId>
-  <version>1.0</version>
+  <version>java17-latest</version>
   <name>Quarkus Sample :: Super-Heroes :: Villains Microservice</name>
   <properties>
     <assertj.version>3.24.2</assertj.version>
@@ -99,6 +99,11 @@
     <dependency>
       <groupId>io.opentelemetry.instrumentation</groupId>
       <artifactId>opentelemetry-jdbc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkiverse.helm</groupId>
+      <artifactId>quarkus-helm</artifactId>
+      <version>0.2.5</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/scripts/generate-helm-charts.sh
+++ b/scripts/generate-helm-charts.sh
@@ -1,0 +1,189 @@
+#!/bin/bash -ex
+
+# Create the deploy/k8s files for each java version of each of the Quarkus services
+# Then add on the ui-super-heroes
+
+INPUT_DIR=src/main/kubernetes
+OUTPUT_DIR=deploy/k8s
+
+OUTPUT_HELM_DIR=deploy/helm
+
+create_output_file() {
+  local output_file=$1
+
+  if [[ ! -f "$output_file" ]]; then
+    echo "Creating output file: $output_file"
+    touch $output_file
+  fi
+}
+
+do_build() {
+  local project=$1
+  local deployment_type=$2
+  local version_tag=$3
+  local javaVersion=$4
+  local kind=$5
+  local container_tag="${version_tag}-latest"
+  local git_server_url="${GITHUB_SERVER_URL:=https://github.com}"
+  local git_repo="${GITHUB_REPOSITORY:=quarkusio/quarkus-super-heroes}"
+  local github_ref_name="${BRANCH:=${GITHUB_REF_NAME:=main}}"
+
+  if [[ "$kind" == "native-" ]]; then
+    local mem_limit="128Mi"
+    local mem_request="32Mi"
+  else
+    local mem_limit="768Mi"
+    local mem_request="256Mi"
+  fi
+
+  if [[ "$deployment_type" == "openshift" ]]; then
+    local expose=true
+  else
+    local expose=false
+  fi
+
+  echo "Generating app resources for $project/$container_tag/$deployment_type"
+  rm -rf $project/target
+
+  $project/mvnw -f $project/pom.xml versions:set clean package \
+    -DskipTests \
+    -DnewVersion=$container_tag \
+    -Dmaven.compiler.release=$javaVersion \
+    -Dquarkus.container-image.tag=$container_tag \
+    -Dquarkus.kubernetes.deployment-target=$deployment_type \
+    -Dquarkus.kubernetes.version=$container_tag \
+    -Dquarkus.kubernetes.ingress.expose=$expose \
+    -Dquarkus.kubernetes.resources.limits.memory=$mem_limit \
+    -Dquarkus.kubernetes.resources.requests.memory=$mem_request \
+    -Dquarkus.kubernetes.annotations.\"app.quarkus.io/vcs-url\"=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY \
+    -Dquarkus.kubernetes.annotations.\"app.quarkus.io/vcs-ref\"=$github_ref_name \
+    -Dquarkus.openshift.version=$container_tag \
+    -Dquarkus.openshift.route.expose=$expose \
+    -Dquarkus.openshift.resources.limits.memory=$mem_limit \
+    -Dquarkus.openshift.resources.requests.memory=$mem_request \
+    -Dquarkus.openshift.annotations.\"app.openshift.io/vcs-url\"=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY \
+    -Dquarkus.openshift.annotations.\"app.openshift.io/vcs-ref\"=$github_ref_name \
+    -Dquarkus.knative.version=$container_tag \
+    -Dquarkus.knative.labels.\"app.openshift.io/runtime\"=quarkus \
+    -Dquarkus.knative.resources.limits.memory=$mem_limit \
+    -Dquarkus.knative.resources.requests.memory=$mem_request \
+    -Dquarkus.knative.annotations.\"app.openshift.io/vcs-url\"=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY \
+    -Dquarkus.knative.annotations.\"app.openshift.io/vcs-ref\"=$github_ref_name \
+    -Dquarkus.helm.version=1.0.0 \
+    -Dquarkus.helm.name=$project-$container_tag-$deployment_type
+}
+
+process_quarkus_project() {
+  local project=$1
+  local deployment_type=$2
+  local version_tag=$3
+  local javaVersion=$4
+  local kind=$5
+  local container_tag="${version_tag}-latest"
+  local output_filename="${version_tag}-${deployment_type}"
+  local app_generated_input_file="$project/target/kubernetes/${deployment_type}.yml"
+  local project_output_file="$project/$OUTPUT_DIR/${output_filename}.yml"
+  local all_apps_output_file="$OUTPUT_DIR/${output_filename}.yml"
+
+  local app_generated_helm_chart="$project/target/helm/${deployment_type}/${project}-${container_tag}-${deployment_type}"
+  local generated_helm_dir="$project/${OUTPUT_HELM_DIR}/${deployment_type}"
+
+  # 1st do the build
+  # The build will generate all the resources for the project
+  do_build $project $deployment_type $version_tag $javaVersion $kind
+
+  rm -rf $generated_helm_dir
+  mkdir $generated_helm_dir
+
+  # Now merge the generated resources to the top level (deploy/helm)
+  if [[ -f "$app_generated_input_file" ]]; then
+    echo "Copying app generated helm ($app_generated_input_file) to $project_output_file and $all_apps_output_file"
+
+    cp -R $app_generated_helm_chart $generated_helm_dir
+
+  fi
+  if [[ "$project" == "rest-fights" ]]; then
+    echo "Copying rest villain and heroes helm charts to the rest fights one "
+
+    cp -R "rest-villains/${OUTPUT_HELM_DIR}/${deployment_type}/rest-villains-${container_tag}-${deployment_type}" "${generated_helm_dir}/${project}-${container_tag}-${deployment_type}/charts/"
+    cp -R "rest-heroes/${OUTPUT_HELM_DIR}/${deployment_type}/rest-heroes-${container_tag}-${deployment_type}" "${generated_helm_dir}/${project}-${container_tag}-${deployment_type}/charts/"
+  fi
+}
+
+process_ui_project() {
+  local deployment_type=$1
+  local version_tag=$2
+  local project="ui-super-heroes"
+  local project_input_directory="$project/$INPUT_DIR"
+  local input_file="$project_input_directory/${deployment_type}.yml"
+  local project_output_file="$project/$OUTPUT_DIR/app-${deployment_type}.yml"
+  local all_apps_output_file="$OUTPUT_DIR/${version_tag}-${deployment_type}.yml"
+
+  rm -rf $project_output_file
+
+  if [[ -f "$input_file" ]]; then
+    create_output_file $project_output_file
+    echo "Copying app input ($input_file) to $project_output_file and $all_apps_output_file"
+    cat $input_file >> $project_output_file
+    cat $input_file >> $all_apps_output_file
+  fi
+}
+
+#create_monitoring() {
+#  local monitoring_name="monitoring"
+#
+#  echo ""
+#  echo "-----------------------------------------"
+#  echo "Creating monitoring"
+#
+#  for deployment_type in "kubernetes" "minikube" "openshift"
+#  do
+#    local output_file_name="${monitoring_name}-${deployment_type}.yml"
+#    local output_file="$OUTPUT_DIR/$output_file_name"
+#    local input_dir="$monitoring_name/k8s"
+#    create_output_file $output_file
+#
+#    if [[ -f "$input_dir/base.yml" ]]; then
+#      echo "Adding base config from $input_dir/base.yml into $output_file"
+#      cat "$input_dir/base.yml" >> $output_file
+#    fi
+#
+#    if [[ -f "$input_dir/${deployment_type}.yml" ]]; then
+#      echo "Adding $deployment_type config from $input_dir/${deployment_type}.yml into $output_file"
+#      cat "$input_dir/${deployment_type}.yml" >> $output_file
+#    fi
+#  done
+#}
+
+#rm -rf $OUTPUT_DIR/*.yml
+
+for kind in "" "native-"
+do
+  if [[ "$kind" == "native-" ]]; then
+    javaVersions=(17)
+  else
+    javaVersions=(11 17)
+  fi
+
+  for javaVersion in ${javaVersions[@]}
+  do
+    for deployment_type in "kubernetes" "minikube" "openshift" "knative"
+    do
+      if [[ "$kind" == "native-" ]]; then
+        version_tag="native"
+      else
+        version_tag="${kind}java${javaVersion}"
+      fi
+
+      for project in "rest-villains" "rest-heroes" "rest-fights" "event-statistics"
+      do
+        process_quarkus_project $project $deployment_type $version_tag $javaVersion $kind
+      done
+
+#      process_ui_project $deployment_type $version_tag
+    done
+  done
+done
+
+## Handle the monitoring
+#create_monitoring


### PR DESCRIPTION
Hi, just wanted to put this as a draft here to get some feedback. The script at generate-helm-charts is similar to the generate-k8s-resource script in its flow.

I was having trouble creating different values files for each deployment type which is why at the moment there are separate directories for each deployment type + java version etc. Having a separate values file for different deployment types would condense it but I wasn't sure how to approach the logic of the builds / copying after so I might need some help if thats the direction that's preferred. 

Thanks !

Closes #130 