### PR TITLE
Change JAVA_OPTS to JAVA_OPTS_APPEND to reenable env config options

### DIFF
--- a/event-statistics/src/main/docker/Dockerfile.jvm
+++ b/event-statistics/src/main/docker/Dockerfile.jvm
@@ -88,5 +88,5 @@ COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8085
 USER 185
-ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/event-statistics/src/main/docker/Dockerfile.legacy-jar
+++ b/event-statistics/src/main/docker/Dockerfile.legacy-jar
@@ -86,5 +86,5 @@ COPY target/*-runner.jar /deployments/quarkus-run.jar
 EXPOSE 8085
 USER 185
 ENV AB_JOLOKIA_OFF=""
-ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/rest-fights/src/main/docker/Dockerfile.jvm
+++ b/rest-fights/src/main/docker/Dockerfile.jvm
@@ -88,5 +88,5 @@ COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8082
 USER 185
-ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/rest-fights/src/main/docker/Dockerfile.legacy-jar
+++ b/rest-fights/src/main/docker/Dockerfile.legacy-jar
@@ -86,5 +86,5 @@ COPY target/*-runner.jar /deployments/quarkus-run.jar
 EXPOSE 8082
 USER 185
 ENV AB_JOLOKIA_OFF=""
-ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/rest-heroes/src/main/docker/Dockerfile.jvm
+++ b/rest-heroes/src/main/docker/Dockerfile.jvm
@@ -88,5 +88,5 @@ COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8083
 USER 185
-ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/rest-heroes/src/main/docker/Dockerfile.legacy-jar
+++ b/rest-heroes/src/main/docker/Dockerfile.legacy-jar
@@ -86,5 +86,5 @@ COPY target/*-runner.jar /deployments/quarkus-run.jar
 EXPOSE 8083
 USER 185
 ENV AB_JOLOKIA_OFF=""
-ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/rest-villains/src/main/docker/Dockerfile.jvm
+++ b/rest-villains/src/main/docker/Dockerfile.jvm
@@ -88,5 +88,5 @@ COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8084
 USER 185
-ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS_APPPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/rest-villains/src/main/docker/Dockerfile.legacy-jar
+++ b/rest-villains/src/main/docker/Dockerfile.legacy-jar
@@ -86,5 +86,5 @@ COPY target/*-runner.jar /deployments/quarkus-run.jar
 EXPOSE 8084
 USER 185
 ENV AB_JOLOKIA_OFF=""
-ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/ui-super-heroes/src/main/docker/Dockerfile.jvm
+++ b/ui-super-heroes/src/main/docker/Dockerfile.jvm
@@ -88,5 +88,5 @@ COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8080
 USER 185
-ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/ui-super-heroes/src/main/docker/Dockerfile.legacy-jar
+++ b/ui-super-heroes/src/main/docker/Dockerfile.legacy-jar
@@ -85,5 +85,5 @@ COPY target/*-runner.jar /deployments/quarkus-run.jar
 
 EXPOSE 8080
 USER 185
-ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"


### PR DESCRIPTION
### What?
Move the Quarkus default java options from `JAVA_OPTS` to `JAVA_OPTS_APPEND`.

### Why?
Setting `JAVA_DEBUG` is not working with the UBI9 images since there have been substantial changes to the run-java.sh script. In the UBI9 images, `JAVA_OPTS` will not be modified once set. Therefore I moved the default options to `JAVA_OPTS_APPEND`. That reenables the UBI8, and also documented functionality.
The relevant diff for the run-java.sh script (left UBI8, right UBI9):

```bash

# Combine all java options													# Combine all java options
get_java_options() {														get_java_options() {
  local java_opts													    |	  local jvm_opts
  local debug_opts														  local debug_opts
															    >	  local proxy_opts
															    >	  local opts
  if [ -f "${JBOSS_CONTAINER_JAVA_JVM_MODULE}/java-default-options" ]; then							  if [ -f "${JBOSS_CONTAINER_JAVA_JVM_MODULE}/java-default-options" ]; then
    java_opts=$(${JBOSS_CONTAINER_JAVA_JVM_MODULE}/java-default-options)						    |	    jvm_opts=$(${JBOSS_CONTAINER_JAVA_JVM_MODULE}/java-default-options)
  fi																  fi
  if [ -f "${JBOSS_CONTAINER_JAVA_JVM_MODULE}/debug-options" ]; then								  if [ -f "${JBOSS_CONTAINER_JAVA_JVM_MODULE}/debug-options" ]; then
    debug_opts=$(${JBOSS_CONTAINER_JAVA_JVM_MODULE}/debug-options)								    debug_opts=$(${JBOSS_CONTAINER_JAVA_JVM_MODULE}/debug-options)
  fi																  fi
  if [ -f "${JBOSS_CONTAINER_JAVA_PROXY_MODULE}/proxy-options" ]; then								  if [ -f "${JBOSS_CONTAINER_JAVA_PROXY_MODULE}/proxy-options" ]; then
    source "${JBOSS_CONTAINER_JAVA_PROXY_MODULE}/proxy-options"									    source "${JBOSS_CONTAINER_JAVA_PROXY_MODULE}/proxy-options"
    proxy_opts="$(proxy_options)"												    proxy_opts="$(proxy_options)"
  fi																  fi
  # Normalize spaces with awk (i.e. trim and elimate double spaces)							    |
  echo "${JAVA_OPTS} $(run_java_options) ${debug_opts} ${proxy_opts} ${java_opts} ${JAVA_OPTS_APPEND}" | awk '$1=$1'	    |	  opts=${JAVA_OPTS-${debug_opts} ${proxy_opts} ${jvm_opts} ${JAVA_OPTS_APPEND}}
															    >	  # Normalize spaces with awk (i.e. trim and eliminate double spaces)
															    >	  echo "${opts}" | awk '$1=$1'
}
```

The breaking change is:
UBI8
```bash

echo "${JAVA_OPTS} $(run_java_options) ${debug_opts} ${proxy_opts} ${java_opts} ${JAVA_OPTS_APPEND}" | awk '$1=$1

```
UBI9
```bash
  opts=${JAVA_OPTS-${debug_opts} ${proxy_opts} ${jvm_opts} ${JAVA_OPTS_APPEND}}
  # Normalize spaces with awk (i.e. trim and eliminate double spaces)
  echo "${opts}" | awk '$1=$1'
```

Since here, `opts` is only set to the evaluated options if `JAVA_OPTS` is unset.

### Side Effects
There are side effects, since before my change `jvm_opts` also did not get applied in the UBI9 images. and now the jvm is started with: `-XX:MaxRAMPercentage=80.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+ExitOnOutOfMemoryError`
Those options differ slightly from the UBI8 jvm options, that got applied by default: `-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+ExitOnOutOfMemoryError`
The change here is in `XX:MaxRAMPercentage`, that is set to `80.0` (UBI9) vs `50.0` (UBI8). That seems to reflect an improvement UBI9 has over UBI8.