### PR TITLE
Use flip cards to expose extra details

### DIFF
--- a/ui-super-heroes/src/main/webui/src/app/fight-list/FightList.js
+++ b/ui-super-heroes/src/main/webui/src/app/fight-list/FightList.js
@@ -1,17 +1,16 @@
 export function FightList({fights}) {
   return (
-    <table className="table table-striped">
+    <table className="fights-table table-striped">
       <thead>
-      <tr>
-        <th className="fight-list-header thead-dark">Id</th>
-        <th className="fight-list-header thead-dark">Fight Date</th>
-        <th className="fight-list-header thead-dark">Winner</th>
-        <th className="fight-list-header thead-dark">Loser</th>
-        <th className="fight-list-header thead-dark">Location</th>
-      </tr>
+        <tr>
+          <th className="fight-list-header thead-dark">Id</th>
+          <th className="fight-list-header thead-dark">Fight Date</th>
+          <th className="fight-list-header thead-dark">Winner</th>
+          <th className="fight-list-header thead-dark">Loser</th>
+          <th className="fight-list-header thead-dark">Location</th>
+        </tr>
       </thead>
       <tbody>
-
 
       {fights && fights.map(element => (
         <tr key={element.id}>

--- a/ui-super-heroes/src/main/webui/src/app/fight/Fight.js
+++ b/ui-super-heroes/src/main/webui/src/app/fight/Fight.js
@@ -3,6 +3,7 @@ import {useEffect, useState} from "react"
 import {faComment} from "@fortawesome/free-solid-svg-icons"
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome"
 import {trackPromise} from "react-promise-tracker";
+import {flipCard} from "../shared/card-flip";
 
 function Fight({onFight}) {
   const [fighters, setFighters] = useState()
@@ -67,19 +68,19 @@ function Fight({onFight}) {
   } else
     return (
       <div id="fight-row">
-        <div className="character flip-card">
+        <div className="character flip-card-container" onClick={() => flipCard('hero-flip-card')}>
           <div className={heroWinnerCss}>
             <h2 className="hero-name">
               {fighters?.hero?.name}<br/>
-              <span style={{fontSize: "small"}}>(Hover over for more info)</span>
+              <span style={{fontSize: "small"}}>(Click for more info)</span>
             </h2>
-            <div className="card-pf-body flip-card-inner">
-              <div className={heroWinnerCss + ' card-pf-body flip-card-front'}>
+            <div id="hero-flip-card" className="card-pf-body flip-card-inner">
+              <div className={heroWinnerCss + ' card-pf-body flip-card flip-card-front'}>
                 <img className="rounded" src={fighters?.hero?.picture} alt="the hero"/>
               </div>
-              <div className={heroWinnerCss + ' card-pf-body flip-card-back'}>
+              <div className={heroWinnerCss + ' card-pf-body flip-card flip-card-back'}>
                 <h4><strong>Hero Details</strong></h4>
-                <table>
+                <table data-testid="hero-details-table">
                   <tbody>
                   <tr>
                     <td className="flipcard-row-header">Level:</td>
@@ -95,7 +96,7 @@ function Fight({onFight}) {
             </div>
             <div className="card-pf-body space-eater">
               {/* This div is a major hack just to take up visible space since the cards use absolute positioning */}
-              <img className="rounded" src={fighters?.hero?.picture} alt="the hero"/>
+              <img className="rounded" src={fighters?.hero?.picture} alt="space-eater"/>
             </div>
           </div>
         </div>
@@ -110,13 +111,13 @@ function Fight({onFight}) {
                 <h4><i className="fas fa-random"></i> NEW LOCATION </h4>
               </button>
               {location && (
-              <div className="flip-card">
-                <div className="flip-card-inner">
-                  <div className="flip-card-front">
+              <div className="flip-card-container" onClick={() => flipCard('location-flip-card')}>
+                <div id="location-flip-card" className="flip-card-inner">
+                  <div className="flip-card flip-card-front">
                     <div className="narration-text"><strong><span data-testid="location-name">{location.name}: </span></strong>{location.description}</div>
                     <div><img alt="Location" className="squared" src={location.picture}></img></div>
                   </div>
-                  <div className="flip-card-back">
+                  <div className="flip-card flip-card-back">
                     <h4><strong>Location Details</strong></h4>
                     <table>
                       <tbody>
@@ -159,17 +160,17 @@ function Fight({onFight}) {
           </div>
         </div>
 
-        <div className="character flip-card">
+        <div className="character flip-card-container" onClick={() => flipCard('villain-flip-card')}>
           <div className={villainWinnerCss}>
             <h2 className="villain-name">
               {fighters?.villain?.name}<br/>
-              <span style={{fontSize: "small"}}>(Hover over for more info)</span>
+              <span style={{fontSize: "small"}}>(Click for more info)</span>
             </h2>
-            <div className="flip-card-inner">
-              <div className={villainWinnerCss + ' card-pf-body flip-card-front'}>
+            <div id="villain-flip-card" className="card-pf-body flip-card-inner">
+              <div className={villainWinnerCss + ' card-pf-body flip-card flip-card-front'}>
                 <img className="rounded" src={fighters?.villain?.picture} alt="the villain"/>
               </div>
-              <div className={villainWinnerCss + ' card-pf-body flip-card-back'}>
+              <div className={villainWinnerCss + ' card-pf-body flip-card flip-card-back'}>
                 <h4><strong>Villain Details</strong></h4>
                 <table>
                   <tbody>
@@ -186,7 +187,7 @@ function Fight({onFight}) {
               </div>
             </div>
             <div className="card-pf-body space-eater">
-              {/* This div is a major hack just to take up visible space since the cards use absolute positioning */}
+            {/* This div is a major hack just to take up visible space since the cards use absolute positioning */}
               <img className="rounded" src={fighters?.villain?.picture} alt="space eater"/>
             </div>
           </div>

--- a/ui-super-heroes/src/main/webui/src/app/fight/Fight.js
+++ b/ui-super-heroes/src/main/webui/src/app/fight/Fight.js
@@ -4,14 +4,11 @@ import {faComment} from "@fortawesome/free-solid-svg-icons"
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome"
 import {trackPromise} from "react-promise-tracker";
 
-
 function Fight({onFight}) {
   const [fighters, setFighters] = useState()
   const [fightResult, setFightResult] = useState()
   const [narration, setNarration] = useState()
   const [location, setLocation] = useState()
-  const [showVillainPowers, setShowVillainPowers] = useState()
-  const [showHeroPowers, setShowHeroPowers] = useState()
 
   const newFighters = () => {
     trackPromise(
@@ -60,6 +57,8 @@ function Fight({onFight}) {
   useEffect(newLocation, [])
 
   const winner = fightResult?.winnerName
+  const heroWinnerCss = (winner === fighters?.hero?.name) ? 'hero-winner-card' : 'off'
+  const villainWinnerCss = (winner === fighters?.villain?.name) ? 'villain-winner-card' : 'off'
 
   if (!fighters) {
     return (
@@ -68,22 +67,35 @@ function Fight({onFight}) {
   } else
     return (
       <div id="fight-row">
-        <div className="character">
-          <div className={winner === fighters.hero.name ? 'hero-winner-card' : 'off'}>
+        <div className="character flip-card">
+          <div className={heroWinnerCss}>
             <h2 className="hero-name">
-              {fighters.hero.name}
+              {fighters?.hero?.name}<br/>
+              <span style={{fontSize: "small"}}>(Hover over for more info)</span>
             </h2>
-            <div className="card-pf-body">
-              <img className="rounded" src={fighters.hero.picture} alt="the hero"/>
-
-              <h2><i className="fas fa-bolt"></i> {fighters.hero.level}</h2>
-              <h2><a data-toggle="collapse" href="#heroPowers" role="button" aria-expanded="false"
-                     aria-controls="heroPowers" onClick={() => setShowHeroPowers(!showHeroPowers)}><i
-                className="powers hero fas fa-atom"></i></a></h2>
-
-              <div className={showHeroPowers ? "" : "collapse"} id="heroPowers">
-                {fighters.hero.powers}
+            <div className="card-pf-body flip-card-inner">
+              <div className={heroWinnerCss + ' card-pf-body flip-card-front'}>
+                <img className="rounded" src={fighters?.hero?.picture} alt="the hero"/>
               </div>
+              <div className={heroWinnerCss + ' card-pf-body flip-card-back'}>
+                <h4><strong>Hero Details</strong></h4>
+                <table>
+                  <tbody>
+                  <tr>
+                    <td className="flipcard-row-header">Level:</td>
+                    <td className="flipcard-row-value">{fighters?.hero?.level}</td>
+                  </tr>
+                  <tr>
+                    <td className="flipcard-row-header">Powers:</td>
+                    <td className="flipcard-row-value">{fighters?.hero?.powers}</td>
+                  </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div className="card-pf-body space-eater">
+              {/* This div is a major hack just to take up visible space since the cards use absolute positioning */}
+              <img className="rounded" src={fighters?.hero?.picture} alt="the hero"/>
             </div>
           </div>
         </div>
@@ -98,10 +110,36 @@ function Fight({onFight}) {
                 <h4><i className="fas fa-random"></i> NEW LOCATION </h4>
               </button>
               {location && (
-                <div className="narration-text"><strong><span data-testid="location-name">{location.name}: </span></strong>{location.description}</div>
+              <div className="flip-card">
+                <div className="flip-card-inner">
+                  <div className="flip-card-front">
+                    <div className="narration-text"><strong><span data-testid="location-name">{location.name}: </span></strong>{location.description}</div>
+                    <div><img alt="Location" className="squared" src={location.picture}></img></div>
+                  </div>
+                  <div className="flip-card-back">
+                    <h4><strong>Location Details</strong></h4>
+                    <table>
+                      <tbody>
+                      <tr>
+                        <td className="flipcard-row-header">Name:</td>
+                        <td className="flipcard-row-value">{location.name}</td>
+                      </tr>
+                      <tr>
+                        <td className="flipcard-row-header">Description:</td>
+                        <td className="flipcard-row-value">{location.description}</td>
+                      </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
               )}
               {location && (
-                <div><img alt="Location" className="squared" src={location.picture}></img></div>
+                  <div className="space-eater">
+                    {/* This div is a major hack just to take up visible space since the cards use absolute positioning */}
+                    <div className="narration-text"><strong><span>{location.name}: </span></strong>{location.description}</div>
+                    <div><img className="squared" src={location.picture}></img></div>
+                  </div>
               )}
               <button onClick={fight} className="btn btn-danger btn-block btn-lg">
                 <h4><i className="fab fa-battle-net"></i> FIGHT !</h4>
@@ -121,27 +159,38 @@ function Fight({onFight}) {
           </div>
         </div>
 
-        <div className="character">
-          <div className={winner === fighters.villain.name ? 'villain-winner-card' : 'off'}>
+        <div className="character flip-card">
+          <div className={villainWinnerCss}>
             <h2 className="villain-name">
-              {fighters.villain.name}
+              {fighters?.villain?.name}<br/>
+              <span style={{fontSize: "small"}}>(Hover over for more info)</span>
             </h2>
-            <div className="card-pf-body">
-              <img className="rounded" src={fighters.villain.picture} alt="the villain"/>
-
-              <h2><i className="fas fa-bolt"></i> {fighters.villain.level}</h2>
-              <h2><a href="#villainPowers" role="button" aria-expanded="false"
-                     aria-controls="villainPowers" onClick={() => setShowVillainPowers(!showVillainPowers)}><i
-                className="powers villain fas fa-atom"></i></a></h2>
-
-              <div className={showVillainPowers ? "" : "collapse"} id="villainPowers">
-                {fighters.villain.powers}
+            <div className="flip-card-inner">
+              <div className={villainWinnerCss + ' card-pf-body flip-card-front'}>
+                <img className="rounded" src={fighters?.villain?.picture} alt="the villain"/>
               </div>
-
+              <div className={villainWinnerCss + ' card-pf-body flip-card-back'}>
+                <h4><strong>Villain Details</strong></h4>
+                <table>
+                  <tbody>
+                  <tr>
+                    <td className="flipcard-row-header">Level:</td>
+                    <td className="flipcard-row-value">{fighters?.villain?.level}</td>
+                  </tr>
+                  <tr>
+                    <td className="flipcard-row-header">Powers:</td>
+                    <td className="flipcard-row-value">{fighters?.villain?.powers}</td>
+                  </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div className="card-pf-body space-eater">
+              {/* This div is a major hack just to take up visible space since the cards use absolute positioning */}
+              <img className="rounded" src={fighters?.villain?.picture} alt="the villain"/>
             </div>
           </div>
         </div>
-
       </div>
     )
 }

--- a/ui-super-heroes/src/main/webui/src/app/fight/Fight.js
+++ b/ui-super-heroes/src/main/webui/src/app/fight/Fight.js
@@ -138,7 +138,7 @@ function Fight({onFight}) {
                   <div className="space-eater">
                     {/* This div is a major hack just to take up visible space since the cards use absolute positioning */}
                     <div className="narration-text"><strong><span>{location.name}: </span></strong>{location.description}</div>
-                    <div><img className="squared" src={location.picture}></img></div>
+                    <div><img className="squared" src={location.picture} alt="space eater"></img></div>
                   </div>
               )}
               <button onClick={fight} className="btn btn-danger btn-block btn-lg">
@@ -187,7 +187,7 @@ function Fight({onFight}) {
             </div>
             <div className="card-pf-body space-eater">
               {/* This div is a major hack just to take up visible space since the cards use absolute positioning */}
-              <img className="rounded" src={fighters?.villain?.picture} alt="the villain"/>
+              <img className="rounded" src={fighters?.villain?.picture} alt="space eater"/>
             </div>
           </div>
         </div>

--- a/ui-super-heroes/src/main/webui/src/app/fight/Fight.test.js
+++ b/ui-super-heroes/src/main/webui/src/app/fight/Fight.test.js
@@ -138,7 +138,12 @@ describe("the fight visualisation", () => {
 
       expect(screen.queryByTestId("location-name").innerHTML).toEqual(location.name + ": ")
       expect(screen.getByAltText("Location")).toHaveAttribute("src", location.picture)
-      expect(screen.getByText(location.description)).toBeInTheDocument()
+
+      const locationDescs = screen.getAllByText(location.description)
+      expect(locationDescs).toHaveLength(3)
+
+      locationDescs.forEach(locationDesc => expect(locationDesc).toBeInTheDocument())
+
       expect(screen.queryByText(/NARRATE THE FIGHT/i)).not.toBeInTheDocument()
     })
 

--- a/ui-super-heroes/src/main/webui/src/app/fight/Fight.test.js
+++ b/ui-super-heroes/src/main/webui/src/app/fight/Fight.test.js
@@ -140,7 +140,7 @@ describe("the fight visualisation", () => {
       expect(screen.getByAltText("Location")).toHaveAttribute("src", location.picture)
 
       const locationDescs = screen.getAllByText(location.description)
-      expect(locationDescs).toHaveLength(3)
+      expect(locationDescs.length).toBeGreaterThan(0)
 
       locationDescs.forEach(locationDesc => expect(locationDesc).toBeInTheDocument())
 

--- a/ui-super-heroes/src/main/webui/src/app/shared/card-flip.js
+++ b/ui-super-heroes/src/main/webui/src/app/shared/card-flip.js
@@ -1,0 +1,4 @@
+export function flipCard(elementId) {
+  var card = document.querySelector('#' + elementId)
+  card?.classList?.toggle('is-flipped')
+}

--- a/ui-super-heroes/src/main/webui/src/styles.css
+++ b/ui-super-heroes/src/main/webui/src/styles.css
@@ -241,7 +241,7 @@ table .flipcard-row-value {
   visibility: hidden;
 }
 
-.flip-card {
+.flip-card-container {
   background-color: transparent;
   width: 100%;
   height: 100%;
@@ -257,17 +257,21 @@ table .flipcard-row-value {
   transform-style: preserve-3d;
 }
 
-.flip-card:hover .flip-card-inner {
-  transform: rotateY(180deg);
-}
-
-.flip-card-front, .flip-card-back {
+.flip-card {
   position: absolute;
   width: 100%;
   -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
 }
 
+.flip-card-front {
+
+}
+
 .flip-card-back {
+  transform: rotateY(180deg);
+}
+
+.is-flipped {
   transform: rotateY(180deg);
 }

--- a/ui-super-heroes/src/main/webui/src/styles.css
+++ b/ui-super-heroes/src/main/webui/src/styles.css
@@ -36,6 +36,7 @@ h1 {
   display: flex;
   flex-direction: column;
   align-items: center;
+  margin-top: 5px;
 }
 
 .btn-block {
@@ -43,7 +44,7 @@ h1 {
   padding-right: 4rem;
 }
 
-.table {
+.fights-table {
   margin-left: 6rem;
   margin-right: 6rem;
   width: 80%;
@@ -135,8 +136,8 @@ td {
   grid-template-columns: 1.2fr 1fr 1.2fr;
   grid-auto-flow: column;
   justify-content: center;
-  margin-left: 2rem;
-  margin-right: 2rem;
+  margin-left: 1rem;
+  margin-right: 5rem;
   margin-bottom: 30px;
   gap: 2rem;
 }
@@ -214,4 +215,59 @@ td {
     -webkit-transform: rotate(360deg);
     transform: rotate(360deg);
   }
+}
+
+table .flipcard-row-header {
+  width: auto;
+  text-align: start;
+  vertical-align: top;
+  font-weight: bold;
+  font-size: small;
+  white-space: pre-wrap;
+  padding-top: 5px;
+}
+
+table .flipcard-row-value {
+  width: 100%;
+  text-align: start;
+  font-size: small;
+  white-space: pre-wrap;
+}
+
+.space-eater {
+  /* This is a hack just so something can eat up space in the document */
+  width: 100%;
+  height: 100%;
+  visibility: hidden;
+}
+
+.flip-card {
+  background-color: transparent;
+  width: 100%;
+  height: 100%;
+  perspective: 1000px;
+}
+
+.flip-card-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  transition: transform 0.6s;
+  transform-style: preserve-3d;
+}
+
+.flip-card:hover .flip-card-inner {
+  transform: rotateY(180deg);
+}
+
+.flip-card-front, .flip-card-back {
+  position: absolute;
+  width: 100%;
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+}
+
+.flip-card-back {
+  transform: rotateY(180deg);
 }


### PR DESCRIPTION
Use flip cards on the hero/villain/location to be able to expose more information.

Hovering the mouse over the hero/villain/location will expose a card we can eventually add more info to:

![image](https://github.com/quarkusio/quarkus-super-heroes/assets/363447/d940ccd6-451a-49c6-929a-396cad917ad2)

![image](https://github.com/quarkusio/quarkus-super-heroes/assets/363447/2a04b221-adf3-429f-9bd1-dfd37bb3e2c3)

![image](https://github.com/quarkusio/quarkus-super-heroes/assets/363447/e3292f96-099e-49cf-8820-3c4c0b0103a2)

![image](https://github.com/quarkusio/quarkus-super-heroes/assets/363447/b64e2150-3252-40c0-8046-7c2f85f12fb0)

Fixes #590