### PR TITLE
Implement ping/pong in event stats websocket

### DIFF
--- a/event-statistics/pom.xml
+++ b/event-statistics/pom.xml
@@ -95,6 +95,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-scheduler</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jacoco</artifactId>
       <scope>test</scope>
     </dependency>

--- a/event-statistics/src/main/java/io/quarkus/sample/superheroes/statistics/endpoint/TeamStatsWebSocket.java
+++ b/event-statistics/src/main/java/io/quarkus/sample/superheroes/statistics/endpoint/TeamStatsWebSocket.java
@@ -5,6 +5,7 @@ import jakarta.inject.Inject;
 import jakarta.websocket.server.ServerEndpoint;
 
 import io.quarkus.sample.superheroes.statistics.domain.TeamScore;
+import io.quarkus.scheduler.Scheduled;
 
 import io.smallrye.mutiny.Multi;
 
@@ -24,5 +25,12 @@ public class TeamStatsWebSocket extends EventStatsWebSocket<TeamScore> {
   @Override
   protected Multi<TeamScore> getStream() {
     return this.teamStatsChannelHolder.getTeamStats();
+  }
+
+  @Scheduled(every = "${pingInterval.teamStats:1m}", delayed = "${pingInterval.teamStats:1m}")
+  @Override
+  void sendPings() {
+    // This is overridden here because of https://github.com/quarkusio/quarkus/issues/38781
+    super.sendPings();
   }
 }

--- a/event-statistics/src/main/java/io/quarkus/sample/superheroes/statistics/endpoint/TopWinnerWebSocket.java
+++ b/event-statistics/src/main/java/io/quarkus/sample/superheroes/statistics/endpoint/TopWinnerWebSocket.java
@@ -4,6 +4,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.websocket.server.ServerEndpoint;
 
 import io.quarkus.sample.superheroes.statistics.domain.Score;
+import io.quarkus.scheduler.Scheduled;
 
 import io.smallrye.mutiny.Multi;
 
@@ -26,5 +27,12 @@ public class TopWinnerWebSocket extends EventStatsWebSocket<Iterable<Score>> {
   @Override
   protected Multi<Iterable<Score>> getStream() {
     return this.topWinnerStatsChannelHolder.getWinners();
+  }
+
+  @Scheduled(every = "${pingInterval.topWinners:1m}", delayed = "${pingInterval.topWinners:1m}")
+  @Override
+  void sendPings() {
+    // This is overridden here because of https://github.com/quarkusio/quarkus/issues/38781
+    super.sendPings();
   }
 }

--- a/event-statistics/src/main/resources/META-INF/resources/index.html
+++ b/event-statistics/src/main/resources/META-INF/resources/index.html
@@ -83,11 +83,12 @@
 
         var top = new WebSocket(protocol + "://" + host + "/stats/winners");
         top.onmessage = function (event) {
+            console.log("[Top Winners Event]: " + event.data);
             updateTop(event.data);
         };
         var team = new WebSocket(protocol + "://" + host + "/stats/team");
         team.onmessage = function(event) {
-            console.log(event.data);
+            console.log("[Team Stats Event]: " + event.data);
             updateTeam(JSON.parse(event.data));
         };
     });


### PR DESCRIPTION
Implement ping/pong in event stats websocket.

After some careful investigation, there is no Javascript API available within the browser to initiate a ping frame that the websocket server will respond to.

Since the server is already maintaining a set of sessions for its consumers, we decided to add a schedule to the server-side to initiate the ping, which the browser will respond to automatically.

This solution was in favor of inventing a custom message that the browser/server would send back & forth and have to decipher. This solution allows us to use the websocket protocol as it is designed. Its just that the server initiates the ping with all of its clients instead of each client initiating the ping to the server.

Fixes #111 