### PR TITLE
Update `QuarkusTestResource` to `WithTestResource` annotations

### DIFF
--- a/event-statistics/src/test/java/io/quarkus/sample/superheroes/statistics/endpoint/WebSocketsIT.java
+++ b/event-statistics/src/test/java/io/quarkus/sample/superheroes/statistics/endpoint/WebSocketsIT.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.kafka.InjectKafkaCompanion;
@@ -68,7 +68,7 @@ import io.vertx.core.Vertx;
  * </p>
  */
 @QuarkusIntegrationTest
-@QuarkusTestResource(value = KafkaCompanionResource.class, restrictToAnnotatedClass = true)
+@WithTestResource(KafkaCompanionResource.class)
 class WebSocketsIT {
 	private static final String HERO_NAME = "Chewbacca";
 	private static final String HERO_TEAM_NAME = "heroes";
@@ -135,7 +135,8 @@ class WebSocketsIT {
       companion.produce(Fight.class)
         .fromRecords(sampleFights.stream()
           .map(fight -> new ProducerRecord<String, Fight>("fights", fight))
-          .collect(Collectors.toList()));
+          .toList()
+        );
 
 			// Wait for our messages to appear in the queue
 			await()
@@ -291,7 +292,7 @@ class WebSocketsIT {
 				}
 
 				return fight.build();
-			}).collect(Collectors.toList());
+			}).toList();
 	}
 
 	@ClientEndpoint

--- a/event-statistics/src/test/java/io/quarkus/sample/superheroes/statistics/endpoint/WebSocketsTests.java
+++ b/event-statistics/src/test/java/io/quarkus/sample/superheroes/statistics/endpoint/WebSocketsTests.java
@@ -12,7 +12,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import jakarta.inject.Inject;
@@ -93,8 +92,8 @@ class WebSocketsTests {
 			// Wait for each client to emit a CONNECT message
 			waitForClientsToStart(teamStatsMessages, teamStatsLatch, topWinnerMessages, topWinnersLatch);
 
-			var expectedTeamStats = createTeamStatsItems().collect(Collectors.toList());
-			var expectedTopWinners = createTopWinnerItems().collect(Collectors.toList());
+			var expectedTeamStats = createTeamStatsItems().toList();
+			var expectedTopWinners = createTopWinnerItems().toList();
 
 			// Wait for our messages to appear in the queue
 			await()

--- a/rest-fights/src/test/java/io/quarkus/sample/superheroes/fight/client/HeaderPropagationTests.java
+++ b/rest-fights/src/test/java/io/quarkus/sample/superheroes/fight/client/HeaderPropagationTests.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 import io.quarkus.sample.superheroes.fight.Fighters;
@@ -34,8 +34,8 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 
 @QuarkusTest
-@QuarkusTestResource(value = HeroesVillainsNarrationWiremockServerResource.class, restrictToAnnotatedClass = true)
-public class HeaderPropagationTests {
+@WithTestResource(HeroesVillainsNarrationWiremockServerResource.class)
+class HeaderPropagationTests {
   private static final String PROPAGATE_HEADER_NAME = "x-propagate";
   private static final String PROPAGATE_HEADER_VALUE = "propagate-value";
 
@@ -80,13 +80,13 @@ public class HeaderPropagationTests {
   ObjectMapper objectMapper;
 
   @BeforeEach
-  public void beforeEach() {
+  void beforeEach() {
     // Reset WireMock
     this.wireMockServer.resetAll();
   }
 
   @Test
-  public void getRandomFightersAllOk() {
+  void getRandomFightersAllOk() {
     this.wireMockServer.stubFor(
       WireMock.get(urlEqualTo(HERO_API_URI))
         .willReturn(okForContentType(APPLICATION_JSON, getDefaultHeroJson()))
@@ -129,7 +129,7 @@ public class HeaderPropagationTests {
 
   @ParameterizedTest(name = DISPLAY_NAME_PLACEHOLDER + "[" + INDEX_PLACEHOLDER + "] (" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
   @MethodSource("helloServiceHeadersPropagateValues")
-  public void helloServiceHeadersPropagate(String requestUri, String downstreamUri, String expectedBody) {
+  void helloServiceHeadersPropagate(String requestUri, String downstreamUri, String expectedBody) {
     this.wireMockServer.stubFor(
       WireMock.get(urlEqualTo(downstreamUri))
         .willReturn(okForContentType(TEXT_PLAIN, expectedBody))

--- a/rest-fights/src/test/java/io/quarkus/sample/superheroes/fight/client/HeroClientTests.java
+++ b/rest-fights/src/test/java/io/quarkus/sample/superheroes/fight/client/HeroClientTests.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 import io.quarkus.sample.superheroes.fight.HeroesVillainsNarrationWiremockServerResource;
@@ -34,7 +34,7 @@ import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
  * @see HeroesVillainsNarrationWiremockServerResource
  */
 @QuarkusTest
-@QuarkusTestResource(value = HeroesVillainsNarrationWiremockServerResource.class, restrictToAnnotatedClass = true)
+@WithTestResource(HeroesVillainsNarrationWiremockServerResource.class)
 class HeroClientTests {
   private static final String HERO_API_BASE_URI = "/api/heroes";
   private static final String HERO_RANDOM_URI = HERO_API_BASE_URI + "/random";
@@ -65,18 +65,18 @@ class HeroClientTests {
   CircuitBreakerMaintenance circuitBreakerMaintenance;
 
   @BeforeEach
-  public void beforeEach() {
+  void beforeEach() {
     this.wireMockServer.resetAll();
   }
 
   @AfterEach
-  public void afterEach() {
+  void afterEach() {
     // Reset all circuit breaker counts after each test
     this.circuitBreakerMaintenance.resetAll();
   }
 
   @Test
-  public void findsRandom() {
+  void findsRandom() {
     this.wireMockServer.stubFor(
       get(urlEqualTo(HERO_RANDOM_URI))
         .willReturn(okForContentType(APPLICATION_JSON, getDefaultHeroJson()))
@@ -102,7 +102,7 @@ class HeroClientTests {
   }
 
   @Test
-  public void recoversFrom404() {
+  void recoversFrom404() {
     this.wireMockServer.stubFor(
       get(urlEqualTo(HERO_RANDOM_URI))
         .willReturn(notFound())
@@ -123,7 +123,7 @@ class HeroClientTests {
   }
 
   @Test
-  public void doesntRecoverFrom500() {
+  void doesntRecoverFrom500() {
     this.wireMockServer.stubFor(
       get(urlEqualTo(HERO_RANDOM_URI))
         .willReturn(serverError())
@@ -175,7 +175,7 @@ class HeroClientTests {
   }
 
   @Test
-  public void helloHeroes() {
+  void helloHeroes() {
     this.wireMockServer.stubFor(
       get(urlEqualTo(HERO_HELLO_URI))
         .willReturn(okForContentType(TEXT_PLAIN, DEFAULT_HELLO_RESPONSE))

--- a/rest-fights/src/test/java/io/quarkus/sample/superheroes/fight/client/LocationClientTests.java
+++ b/rest-fights/src/test/java/io/quarkus/sample/superheroes/fight/client/LocationClientTests.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.wiremock.grpc.dsl.WireMockGrpcService;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 import io.quarkus.sample.superheroes.fight.FightLocation;
@@ -32,7 +32,7 @@ import io.smallrye.faulttolerance.api.CircuitBreakerState;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 
 @QuarkusTest
-@QuarkusTestResource(value = LocationsWiremockGrpcServerResource.class, restrictToAnnotatedClass = true)
+@WithTestResource(LocationsWiremockGrpcServerResource.class)
 class LocationClientTests {
 	private static final String DEFAULT_HELLO_RESPONSE = "Hello locations!";
 	private static final String DEFAULT_LOCATION_NAME = "Gotham City";

--- a/rest-fights/src/test/java/io/quarkus/sample/superheroes/fight/client/VillainClientTests.java
+++ b/rest-fights/src/test/java/io/quarkus/sample/superheroes/fight/client/VillainClientTests.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 import io.quarkus.sample.superheroes.fight.HeroesVillainsNarrationWiremockServerResource;
@@ -34,7 +34,7 @@ import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
  * @see HeroesVillainsNarrationWiremockServerResource
  */
 @QuarkusTest
-@QuarkusTestResource(value = HeroesVillainsNarrationWiremockServerResource.class, restrictToAnnotatedClass = true)
+@WithTestResource(HeroesVillainsNarrationWiremockServerResource.class)
 class VillainClientTests {
   private static final String VILLAIN_API_BASE_URI = "/api/villains";
   private static final String VILLAIN_RANDOM_URI = VILLAIN_API_BASE_URI + "/random";
@@ -66,18 +66,18 @@ class VillainClientTests {
   CircuitBreakerMaintenance circuitBreakerMaintenance;
 
   @BeforeEach
-  public void beforeEach() {
+  void beforeEach() {
     this.wireMockServer.resetAll();
   }
 
   @AfterEach
-  public void afterEach() {
+  void afterEach() {
     // Reset all circuit breaker counts after each test
     this.circuitBreakerMaintenance.resetAll();
   }
 
   @Test
-  public void findsRandom() {
+  void findsRandom() {
     this.wireMockServer.stubFor(
       get(urlEqualTo(VILLAIN_RANDOM_URI))
         .willReturn(okForContentType(APPLICATION_JSON, getDefaultVillainJson()))
@@ -103,7 +103,7 @@ class VillainClientTests {
   }
 
   @Test
-  public void recoversFrom404() {
+  void recoversFrom404() {
     this.wireMockServer.stubFor(
       get(urlEqualTo(VILLAIN_RANDOM_URI))
         .willReturn(notFound())
@@ -124,7 +124,7 @@ class VillainClientTests {
   }
 
   @Test
-  public void doesntRecoverFrom500() {
+  void doesntRecoverFrom500() {
     this.wireMockServer.stubFor(
       get(urlEqualTo(VILLAIN_RANDOM_URI))
         .willReturn(serverError())
@@ -176,7 +176,7 @@ class VillainClientTests {
   }
 
   @Test
-  public void helloVillains() {
+  void helloVillains() {
     this.wireMockServer.stubFor(
       get(urlEqualTo(VILLAIN_HELLO_URI))
         .willReturn(okForContentType(TEXT_PLAIN, DEFAULT_HELLO_RESPONSE))

--- a/rest-fights/src/test/java/io/quarkus/sample/superheroes/fight/rest/FightResourceIT.java
+++ b/rest-fights/src/test/java/io/quarkus/sample/superheroes/fight/rest/FightResourceIT.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.wiremock.grpc.dsl.WireMockGrpcService;
 
 import io.quarkus.logging.Log;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.kafka.InjectKafkaCompanion;
@@ -96,9 +96,9 @@ import io.vertx.core.Vertx;
  */
 @QuarkusIntegrationTest
 @TestProfile(ShorterTimeoutsProfile.class)
-@QuarkusTestResource(value = HeroesVillainsNarrationWiremockServerResource.class, restrictToAnnotatedClass = true)
-@QuarkusTestResource(value = KafkaCompanionResource.class, restrictToAnnotatedClass = true)
-@QuarkusTestResource(value = LocationsWiremockGrpcServerResource.class, restrictToAnnotatedClass = true)
+@WithTestResource(HeroesVillainsNarrationWiremockServerResource.class)
+@WithTestResource(KafkaCompanionResource.class)
+@WithTestResource(LocationsWiremockGrpcServerResource.class)
 @TestMethodOrder(OrderAnnotation.class)
 class FightResourceIT {
 	private static final int DEFAULT_ORDER = 0;
@@ -1691,8 +1691,4 @@ class FightResourceIT {
 	private static String getDefaultHeroJson() {
 		return writeAsJson(DEFAULT_HERO);
 	}
-
-  private static String getDefaultLocationJson() {
-    return writeAsJson(DEFAULT_LOCATION);
-  }
 }


### PR DESCRIPTION
Replaced deprecated `@QuarkusTestResource` annotations with the new `@WithTestResource` annotations across multiple test classes. This ensures compatibility with the latest Quarkus testing utilities and simplifies resource management.