### PR TITLE
Update versions of infra services

### DIFF
--- a/event-statistics/src/main/docker-compose/infra.yml
+++ b/event-statistics/src/main/docker-compose/infra.yml
@@ -1,6 +1,6 @@
 
   apicurio:
-    image: quay.io/apicurio/apicurio-registry-mem:2.4.2.Final
+    image: quay.io/apicurio/apicurio-registry-mem:2.6.5.Final
     container_name: apicurio
     ports:
       - "8086:8086"
@@ -9,7 +9,7 @@
       QUARKUS_HTTP_PORT: 8086
 
   fights-kafka:
-    image: quay.io/strimzi/kafka:0.41.0-kafka-3.7.0
+    image: quay.io/strimzi/kafka:0.43.0-kafka-3.8.0
     container_name: fights-kafka
     depends_on:
       - apicurio

--- a/event-statistics/src/main/kubernetes/common.yml
+++ b/event-statistics/src/main/kubernetes/common.yml
@@ -45,7 +45,7 @@ spec:
         system: quarkus-super-heroes
     spec:
       containers:
-        - image: quay.io/strimzi/kafka:0.41.0-kafka-3.7.0
+        - image: quay.io/strimzi/kafka:0.43.0-kafka-3.8.0
           name: fights-kafka
           ports:
             - containerPort: 9092
@@ -116,7 +116,7 @@ spec:
         system: quarkus-super-heroes
     spec:
       containers:
-        - image: quay.io/apicurio/apicurio-registry-mem:2.4.2.Final
+        - image: quay.io/apicurio/apicurio-registry-mem:2.6.5.Final
           name: apicurio
           livenessProbe:
             failureThreshold: 3

--- a/event-statistics/src/main/resources/application.properties
+++ b/event-statistics/src/main/resources/application.properties
@@ -13,6 +13,7 @@ mp.messaging.incoming.fights.auto.offset.reset=earliest
 mp.messaging.incoming.fights.broadcast=true
 mp.messaging.incoming.fights.enable.auto.commit=false
 %test.mp.messaging.incoming.fights.connector=smallrye-in-memory
+quarkus.apicurio-registry.devservices.image-name=quay.io/apicurio/apicurio-registry-mem:2.6.5.Final
 
 ## Logging configuration
 quarkus.log.category."io.quarkus.sample.superheroes".level=DEBUG

--- a/grpc-locations/src/main/docker-compose/infra.yml
+++ b/grpc-locations/src/main/docker-compose/infra.yml
@@ -1,6 +1,6 @@
 
   locations-db:
-    image: mariadb:10.11
+    image: mariadb:11.5
     container_name: locations-db
     ports:
       - "3306"

--- a/grpc-locations/src/main/kubernetes/common.yml
+++ b/grpc-locations/src/main/kubernetes/common.yml
@@ -89,7 +89,7 @@ spec:
             - name: locations-db-init
               mountPath: /tmp/dbinit
       containers:
-        - image: bitnami/mariadb:10.11
+        - image: bitnami/mariadb:11.5
           name: locations-db
           ports:
             - containerPort: 3306

--- a/grpc-locations/src/main/resources/application.yml
+++ b/grpc-locations/src/main/resources/application.yml
@@ -24,6 +24,8 @@ quarkus:
   datasource:
     jdbc:
       telemetry: true
+    devservices:
+      image-name: mariadb:11.5
   otel:
     resource:
       attributes: "app=${quarkus.application.name},application=grpc-locations,system=quarkus-super-heroes"

--- a/monitoring/config/otel-collector-config.yml
+++ b/monitoring/config/otel-collector-config.yml
@@ -5,8 +5,8 @@ receivers:
         endpoint: otel-collector:4317
 
 exporters:
-  jaeger:
-    endpoint: jaeger:14250
+  otlp/jaeger:
+    endpoint: jaeger:4317
     tls:
       insecure: true
 
@@ -26,4 +26,4 @@ service:
       processors:
         - batch
       exporters:
-        - jaeger
+        - otlp/jaeger

--- a/monitoring/docker-compose/monitoring.yml
+++ b/monitoring/docker-compose/monitoring.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
 
   prometheus:
-    image: quay.io/prometheus/prometheus:v2.43.0
+    image: quay.io/prometheus/prometheus:v2.55.0
     container_name: prometheus
     ports:
       - "9090:9090"
@@ -16,9 +16,10 @@ services:
       - "16686:16686" # Jaeger UI
       - "14268"       # Accept thrift spans
       - "14250"       # Accept gRPC spans
+      - "4317"        # Otel gRPC
 
   otel-collector:
-    image: otel/opentelemetry-collector:0.75.0
+    image: otel/opentelemetry-collector:0.112.0
     container_name: otel-collector
     command:
       - "--config=/conf/otel-collector-config.yml"

--- a/monitoring/k8s/base.yml
+++ b/monitoring/k8s/base.yml
@@ -79,8 +79,8 @@ data:
           grpc:
 
     exporters:
-      jaeger:
-        endpoint: jaeger:14250
+      otlp/jaeger:
+        endpoint: jaeger:4317
         tls:
           insecure: true
 
@@ -100,7 +100,7 @@ data:
           processors:
             - batch
           exporters:
-            - jaeger
+            - otlp/jaeger
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -129,7 +129,7 @@ spec:
         role: monitoring
     spec:
       containers:
-        - image: quay.io/prometheus/prometheus:v2.43.0
+        - image: quay.io/prometheus/prometheus:v2.55.0
           name: prometheus
           ports:
             - containerPort: 9090
@@ -181,6 +181,7 @@ spec:
             - containerPort: 16686
             - containerPort: 14268
             - containerPort: 14250
+            - containerPort: 4317
           resources:
             limits:
               memory: 128Mi
@@ -214,7 +215,7 @@ spec:
         role: monitoring
     spec:
       containers:
-        - image: otel/opentelemetry-collector:0.75.0
+        - image: otel/opentelemetry-collector:0.112.0
           name: otel-collector
           args:
             - "--config=/conf/otel-collector-config.yml"

--- a/rest-fights/src/main/docker-compose/infra.yml
+++ b/rest-fights/src/main/docker-compose/infra.yml
@@ -1,6 +1,6 @@
 
   fights-db:
-    image: mongo:5.0
+    image: mongo:7.0
     container_name: fights-db
     ports:
       - "27017"
@@ -12,7 +12,7 @@
       - ../../../rest-fights/deploy/db-init/initialize-database.js:/docker-entrypoint-initdb.d/1-init-db.js
 
   apicurio:
-    image: quay.io/apicurio/apicurio-registry-mem:2.4.2.Final
+    image: quay.io/apicurio/apicurio-registry-mem:2.6.5.Final
     container_name: apicurio
     ports:
       - "8086:8086"
@@ -21,7 +21,7 @@
       QUARKUS_HTTP_PORT: 8086
 
   fights-kafka:
-    image: quay.io/strimzi/kafka:0.41.0-kafka-3.7.0
+    image: quay.io/strimzi/kafka:0.43.0-kafka-3.8.0
     container_name: fights-kafka
     depends_on:
       - apicurio

--- a/rest-fights/src/main/kubernetes/common.yml
+++ b/rest-fights/src/main/kubernetes/common.yml
@@ -63,7 +63,7 @@ spec:
         system: quarkus-super-heroes
     spec:
       containers:
-        - image: bitnami/mongodb:5.0
+        - image: bitnami/mongodb:7.0
           name: fights-db
           ports:
             - containerPort: 27017
@@ -116,7 +116,7 @@ spec:
         system: quarkus-super-heroes
     spec:
       containers:
-        - image: quay.io/strimzi/kafka:0.41.0-kafka-3.7.0
+        - image: quay.io/strimzi/kafka:0.43.0-kafka-3.8.0
           name: fights-kafka
           ports:
             - containerPort: 9092
@@ -187,7 +187,7 @@ spec:
         system: quarkus-super-heroes
     spec:
       containers:
-        - image: quay.io/apicurio/apicurio-registry-mem:2.4.2.Final
+        - image: quay.io/apicurio/apicurio-registry-mem:2.6.5.Final
           name: apicurio
           livenessProbe:
             failureThreshold: 3

--- a/rest-fights/src/main/resources/application.properties
+++ b/rest-fights/src/main/resources/application.properties
@@ -81,6 +81,7 @@ mp.messaging.outgoing.fights.topic=fights
 mp.messaging.outgoing.fights.apicurio.registry.auto-register=true
 %test.mp.messaging.outgoing.fights.connector=smallrye-in-memory
 %test.mp.messaging.outgoing.fights.merge=true
+quarkus.apicurio-registry.devservices.image-name=quay.io/apicurio/apicurio-registry-mem:2.6.5.Final
 
 ## Logging configuration
 quarkus.log.category."io.quarkus.sample.superheroes".level=DEBUG

--- a/rest-heroes/src/main/docker-compose/infra.yml
+++ b/rest-heroes/src/main/docker-compose/infra.yml
@@ -1,6 +1,6 @@
 
   heroes-db:
-    image: postgres:14
+    image: postgres:16
     container_name: heroes-db
     ports:
       - "5432"

--- a/rest-heroes/src/main/kubernetes/common.yml
+++ b/rest-heroes/src/main/kubernetes/common.yml
@@ -89,7 +89,7 @@ spec:
             - name: heroes-db-init-data
               mountPath: /docker-entrypoint-initdb.d
       containers:
-        - image: bitnami/postgresql:14
+        - image: bitnami/postgresql:16
           name: heroes-db
           ports:
             - containerPort: 5432

--- a/rest-heroes/src/main/resources/application.yml
+++ b/rest-heroes/src/main/resources/application.yml
@@ -3,6 +3,9 @@ quarkus:
     name: rest-heroes
   banner:
     path: banner.txt
+  datasource:
+    devservices:
+      image-name: postgres:16
   log:
     level: INFO
     category:

--- a/rest-villains/src/main/docker-compose/infra.yml
+++ b/rest-villains/src/main/docker-compose/infra.yml
@@ -1,6 +1,6 @@
 
   villains-db:
-    image: postgres:14
+    image: postgres:16
     container_name: villains-db
     ports:
       - "5432"

--- a/rest-villains/src/main/kubernetes/common.yml
+++ b/rest-villains/src/main/kubernetes/common.yml
@@ -88,7 +88,7 @@ spec:
             - name: villains-db-init-data
               mountPath: /docker-entrypoint-initdb.d
       containers:
-        - image: bitnami/postgresql:14
+        - image: bitnami/postgresql:16
           name: villains-db
           ports:
             - containerPort: 5432

--- a/rest-villains/src/main/resources/application.properties
+++ b/rest-villains/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 quarkus.application.name=rest-villains
 quarkus.banner.path=banner.txt
+quarkus.datasource.devservices.image-name=postgres:16
 
 ## HTTP configuration
 quarkus.http.port=8084

--- a/ui-super-heroes/src/main/resources/application.properties
+++ b/ui-super-heroes/src/main/resources/application.properties
@@ -4,7 +4,7 @@ quarkus.banner.path=banner.txt
 quarkus.http.test-port=0
 
 quarkus.quinoa.package-manager-install=true
-quarkus.quinoa.package-manager-install.node-version=20.11.0
+quarkus.quinoa.package-manager-install.node-version=20.18.0
 
 # Fight service config
 api.base.url=http://localhost:8082


### PR DESCRIPTION
Update the versions of infra services:
- Apicurio `2.4.2.Final` -> `2.6.5.Final`
- Strimzi `0.41.0-kafka-3.7.0` -> `0.43.0-kafka-3.8.0`
- MariaDB `10.11` -> `11.5`
- Prometheus `2.43.0` -> `2.55.0`
- OpenTelemetry Collector `0.75.0` -> `0.112.0`
- MongoDB `5.0` -> `7.0`
- PostgreSQL `14` -> `16`
- Node.js `20.11.0` -> `20.18.0`