### PR TITLE
Include fighter picture URLs in image generation request

### DIFF
--- a/rest-fights/openapi-schema.yml
+++ b/rest-fights/openapi-schema.yml
@@ -260,12 +260,16 @@ paths:
       summary: Generate an image from a narration
       requestBody:
         content:
-          text/plain:
+          application/json:
             schema:
-              type: string
+              $ref: '#/components/schemas/ImageGenerationRequest'
             examples:
-              narration:
-                value: This is your fight narration!
+              request:
+                value:
+                  narration: In the dark, shadowy alleys of Gotham City, a fierce battle
+                    unfolded between two formidable opponents.
+                  winnerPictureUrl: https://raw.githubusercontent.com/quarkusio/quarkus-super-heroes/characterdata/images/luke-skywalker-2563509063968639219.jpg
+                  loserPictureUrl: https://raw.githubusercontent.com/quarkusio/quarkus-super-heroes/characterdata/images/anakin-skywalker--8429855148488965479.jpg
         required: true
       responses:
         "200":
@@ -279,7 +283,7 @@ paths:
                   value:
                     imageUrl: https://dummyimage.com/240x320/1e8fff/ffffff&text=Fallback+Image
         "400":
-          description: Invalid (or missing) narration
+          description: Invalid (or missing) request
   /api/fights/randomfighters:
     get:
       tags:
@@ -425,6 +429,19 @@ components:
       type: object
       properties:
         imageUrl:
+          type: string
+    ImageGenerationRequest:
+      description: Request for image generation from a narration
+      required:
+      - narration
+      type: object
+      properties:
+        narration:
+          pattern: \S
+          type: string
+        winnerPictureUrl:
+          type: string
+        loserPictureUrl:
           type: string
     FightLocation:
       description: Location of a fight

--- a/rest-fights/src/main/java/io/quarkus/sample/superheroes/fight/ImageGenerationRequest.java
+++ b/rest-fights/src/main/java/io/quarkus/sample/superheroes/fight/ImageGenerationRequest.java
@@ -1,0 +1,9 @@
+package io.quarkus.sample.superheroes.fight;
+
+import jakarta.validation.constraints.NotBlank;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+@Schema(description = "Request for image generation from a narration")
+public record ImageGenerationRequest(@NotBlank String narration, String winnerPictureUrl, String loserPictureUrl) {
+}

--- a/rest-fights/src/main/java/io/quarkus/sample/superheroes/fight/client/NarrationClient.java
+++ b/rest-fights/src/main/java/io/quarkus/sample/superheroes/fight/client/NarrationClient.java
@@ -39,9 +39,9 @@ public interface NarrationClient {
   @POST
   @Path("/image")
   @Produces(MediaType.APPLICATION_JSON)
-  @Consumes(MediaType.TEXT_PLAIN)
+  @Consumes(MediaType.APPLICATION_JSON)
   @WithSpan(kind = SpanKind.CLIENT, value = "NarrationClient.generateImageFromNarration")
-  Uni<FightImage> generateImageFromNarration(@SpanAttribute("arg.narration") String narration);
+  Uni<FightImage> generateImageFromNarration(@SpanAttribute("arg.request") NarrationImageGenerationRequest request);
 
   /**
    * HTTP <code>GET</code> call to {@code /api/narration/hello} on the Narration service

--- a/rest-fights/src/main/java/io/quarkus/sample/superheroes/fight/client/NarrationImageGenerationRequest.java
+++ b/rest-fights/src/main/java/io/quarkus/sample/superheroes/fight/client/NarrationImageGenerationRequest.java
@@ -1,0 +1,4 @@
+package io.quarkus.sample.superheroes.fight.client;
+
+public record NarrationImageGenerationRequest(String narration, String winnerPictureUrl, String loserPictureUrl) {
+}

--- a/rest-fights/src/main/java/io/quarkus/sample/superheroes/fight/mapping/ImageGenerationRequestMapper.java
+++ b/rest-fights/src/main/java/io/quarkus/sample/superheroes/fight/mapping/ImageGenerationRequestMapper.java
@@ -1,0 +1,13 @@
+package io.quarkus.sample.superheroes.fight.mapping;
+
+import static org.mapstruct.MappingConstants.ComponentModel.JAKARTA_CDI;
+
+import org.mapstruct.Mapper;
+
+import io.quarkus.sample.superheroes.fight.ImageGenerationRequest;
+import io.quarkus.sample.superheroes.fight.client.NarrationImageGenerationRequest;
+
+@Mapper(componentModel = JAKARTA_CDI)
+public interface ImageGenerationRequestMapper {
+  NarrationImageGenerationRequest toClientRequest(ImageGenerationRequest request);
+}

--- a/rest-fights/src/main/java/io/quarkus/sample/superheroes/fight/rest/Examples.java
+++ b/rest-fights/src/main/java/io/quarkus/sample/superheroes/fight/rest/Examples.java
@@ -96,4 +96,12 @@ final class Examples {
       "imageUrl": "https://dummyimage.com/240x320/1e8fff/ffffff&text=Fallback+Image"
     }
     """;
+
+  static final String EXAMPLE_IMAGE_GENERATION_REQUEST = """
+    {
+      "narration": "In the dark, shadowy alleys of Gotham City, a fierce battle unfolded between two formidable opponents.",
+      "winnerPictureUrl": "https://raw.githubusercontent.com/quarkusio/quarkus-super-heroes/characterdata/images/luke-skywalker-2563509063968639219.jpg",
+      "loserPictureUrl": "https://raw.githubusercontent.com/quarkusio/quarkus-super-heroes/characterdata/images/anakin-skywalker--8429855148488965479.jpg"
+    }
+    """;
 }

--- a/rest-fights/src/main/java/io/quarkus/sample/superheroes/fight/rest/FightResource.java
+++ b/rest-fights/src/main/java/io/quarkus/sample/superheroes/fight/rest/FightResource.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Optional;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
@@ -37,6 +36,7 @@ import io.quarkus.sample.superheroes.fight.FightImage;
 import io.quarkus.sample.superheroes.fight.FightLocation;
 import io.quarkus.sample.superheroes.fight.FightRequest;
 import io.quarkus.sample.superheroes.fight.Fighters;
+import io.quarkus.sample.superheroes.fight.ImageGenerationRequest;
 import io.quarkus.sample.superheroes.fight.client.FightToNarrate;
 import io.quarkus.sample.superheroes.fight.service.FightService;
 
@@ -228,7 +228,7 @@ public class FightResource {
   @POST
   @Path("/narrate/image")
   @Produces(MediaType.APPLICATION_JSON)
-  @Consumes(MediaType.TEXT_PLAIN)
+  @Consumes(MediaType.APPLICATION_JSON)
   @Operation(summary = "Generate an image from a narration")
   @APIResponse(
     responseCode = "200",
@@ -240,20 +240,20 @@ public class FightResource {
   )
   @APIResponse(
     responseCode = "400",
-    description = "Invalid (or missing) narration"
+    description = "Invalid (or missing) request"
   )
   public Uni<FightImage> generateImageFromNarration(
     @RequestBody(
-      name = "narration",
+      name = "request",
       required = true,
       content = @Content(
-        schema = @Schema(implementation = String.class),
-        examples = @ExampleObject(name = "narration", value = "This is your fight narration!")
+        schema = @Schema(implementation = ImageGenerationRequest.class),
+        examples = @ExampleObject(name = "request", value = Examples.EXAMPLE_IMAGE_GENERATION_REQUEST)
       )
     )
-    @NotBlank String narration) {
-    return this.service.generateImageFromNarration(narration)
-      .invoke(image -> Log.debugf("Image (%s) generated from narration: %s", image, narration));
+    @NotNull @Valid ImageGenerationRequest request) {
+    return this.service.generateImageFromNarration(request)
+      .invoke(image -> Log.debugf("Image (%s) generated from request: %s", image, request));
   }
 
 	@GET

--- a/rest-fights/src/main/java/io/quarkus/sample/superheroes/fight/service/FightService.java
+++ b/rest-fights/src/main/java/io/quarkus/sample/superheroes/fight/service/FightService.java
@@ -27,6 +27,7 @@ import io.quarkus.sample.superheroes.fight.FightImage;
 import io.quarkus.sample.superheroes.fight.FightLocation;
 import io.quarkus.sample.superheroes.fight.FightRequest;
 import io.quarkus.sample.superheroes.fight.Fighters;
+import io.quarkus.sample.superheroes.fight.ImageGenerationRequest;
 import io.quarkus.sample.superheroes.fight.client.FightToNarrate;
 import io.quarkus.sample.superheroes.fight.client.Hero;
 import io.quarkus.sample.superheroes.fight.client.HeroClient;
@@ -36,6 +37,7 @@ import io.quarkus.sample.superheroes.fight.client.Villain;
 import io.quarkus.sample.superheroes.fight.client.VillainClient;
 import io.quarkus.sample.superheroes.fight.config.FightConfig;
 import io.quarkus.sample.superheroes.fight.mapping.FightMapper;
+import io.quarkus.sample.superheroes.fight.mapping.ImageGenerationRequestMapper;
 
 import io.opentelemetry.instrumentation.annotations.SpanAttribute;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
@@ -55,9 +57,11 @@ public class FightService {
 	private final MutinyEmitter<io.quarkus.sample.superheroes.fight.schema.Fight> emitter;
 	private final FightConfig fightConfig;
   private final FightMapper fightMapper;
+  private final ImageGenerationRequestMapper imageGenerationRequestMapper;
 	private final Random random = new Random();
 
-	public FightService(HeroClient heroClient, VillainClient villainClient, @RestClient NarrationClient narrationClient, LocationClient locationClient, @Channel("fights") MutinyEmitter<io.quarkus.sample.superheroes.fight.schema.Fight> emitter, FightConfig fightConfig, FightMapper fightMapper) {
+  @SuppressWarnings("java:S107") // Suppressing "Methods should not have too many parameters" for constructor injection
+	public FightService(HeroClient heroClient, VillainClient villainClient, @RestClient NarrationClient narrationClient, LocationClient locationClient, @Channel("fights") MutinyEmitter<io.quarkus.sample.superheroes.fight.schema.Fight> emitter, FightConfig fightConfig, FightMapper fightMapper, ImageGenerationRequestMapper imageGenerationRequestMapper) {
 		this.heroClient = heroClient;
 		this.villainClient = villainClient;
     this.narrationClient = narrationClient;
@@ -65,6 +69,7 @@ public class FightService {
 		this.emitter = emitter;
 		this.fightConfig = fightConfig;
     this.fightMapper = fightMapper;
+    this.imageGenerationRequestMapper = imageGenerationRequestMapper;
   }
 
 	/**
@@ -245,7 +250,8 @@ public class FightService {
       .invoke(n -> Log.warn("Falling back on Narration"));
   }
 
-  Uni<FightImage> fallbackGenerateImageFromNarration(String narration) {
+  @SuppressWarnings("unused")
+  Uni<FightImage> fallbackGenerateImageFromNarration(ImageGenerationRequest request) {
     var fallbackImageGeneration = this.fightConfig.narration().fallbackImageGeneration();
 
     return Uni.createFrom().item(new FightImage(fallbackImageGeneration.imageUrl()))
@@ -285,9 +291,9 @@ public class FightService {
   @Retry(maxRetries = 3, delay = 200, delayUnit = ChronoUnit.MILLIS)
 	@Fallback(fallbackMethod = "fallbackGenerateImageFromNarration")
   @WithSpan("FightService.generateImageFromNarration")
-  public Uni<FightImage> generateImageFromNarration(@SpanAttribute("arg.narration") String narration) {
-    Log.debugf("Generating image for narration: %s", narration);
-    return this.narrationClient.generateImageFromNarration(narration);
+  public Uni<FightImage> generateImageFromNarration(@SpanAttribute("arg.request") ImageGenerationRequest request) {
+    Log.debugf("Generating image for request: %s", request);
+    return this.narrationClient.generateImageFromNarration(this.imageGenerationRequestMapper.toClientRequest(request));
   }
 
   @WithSpan("FightService.persistFight")

--- a/rest-fights/src/test/java/io/quarkus/sample/superheroes/fight/mapping/ImageGenerationRequestMapperTests.java
+++ b/rest-fights/src/test/java/io/quarkus/sample/superheroes/fight/mapping/ImageGenerationRequestMapperTests.java
@@ -1,0 +1,37 @@
+package io.quarkus.sample.superheroes.fight.mapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+import io.quarkus.sample.superheroes.fight.ImageGenerationRequest;
+import io.quarkus.sample.superheroes.fight.client.NarrationImageGenerationRequest;
+
+class ImageGenerationRequestMapperTests {
+  private static final String DEFAULT_NARRATION = "The hero defeated the villain in an epic battle.";
+  private static final String DEFAULT_WINNER_PICTURE_URL = "https://example.com/winner.png";
+  private static final String DEFAULT_LOSER_PICTURE_URL = "https://example.com/loser.png";
+
+  ImageGenerationRequestMapper mapper = Mappers.getMapper(ImageGenerationRequestMapper.class);
+
+  @Test
+  void mappingWorks() {
+    var request = new ImageGenerationRequest(DEFAULT_NARRATION, DEFAULT_WINNER_PICTURE_URL, DEFAULT_LOSER_PICTURE_URL);
+
+    assertThat(this.mapper.toClientRequest(request))
+      .isNotNull()
+      .usingRecursiveComparison()
+      .isEqualTo(new NarrationImageGenerationRequest(DEFAULT_NARRATION, DEFAULT_WINNER_PICTURE_URL, DEFAULT_LOSER_PICTURE_URL));
+  }
+
+  @Test
+  void mappingWorksWithNullUrls() {
+    var request = new ImageGenerationRequest(DEFAULT_NARRATION, null, null);
+
+    assertThat(this.mapper.toClientRequest(request))
+      .isNotNull()
+      .usingRecursiveComparison()
+      .isEqualTo(new NarrationImageGenerationRequest(DEFAULT_NARRATION, null, null));
+  }
+}

--- a/rest-fights/src/test/java/io/quarkus/sample/superheroes/fight/rest/FightResourceIT.java
+++ b/rest-fights/src/test/java/io/quarkus/sample/superheroes/fight/rest/FightResourceIT.java
@@ -46,6 +46,7 @@ import io.quarkus.sample.superheroes.fight.FightImage;
 import io.quarkus.sample.superheroes.fight.FightLocation;
 import io.quarkus.sample.superheroes.fight.FightRequest;
 import io.quarkus.sample.superheroes.fight.Fighters;
+import io.quarkus.sample.superheroes.fight.ImageGenerationRequest;
 import io.quarkus.sample.superheroes.fight.HeroesVillainsNarrationWiremockServerResource;
 import io.quarkus.sample.superheroes.fight.InjectGrpcWireMock;
 import io.quarkus.sample.superheroes.fight.InjectWireMock;
@@ -600,14 +601,16 @@ class FightResourceIT {
     this.wireMockServer.stubFor(
       WireMock.post(urlEqualTo(NARRATION_API_IMAGE_GEN_URI))
         .withHeader(ACCEPT, containing(APPLICATION_JSON))
-        .withHeader(CONTENT_TYPE, containing(TEXT_PLAIN))
+        .withHeader(CONTENT_TYPE, containing(APPLICATION_JSON))
         .willReturn(okJson(getDefaultImageJson()))
     );
 
+    var request = new ImageGenerationRequest(DEFAULT_NARRATION, null, null);
+
     var image = given()
       .accept(JSON)
-      .contentType(TEXT)
-      .body(DEFAULT_NARRATION)
+      .contentType(JSON)
+      .body(request)
       .when().post("/api/fights/narrate/image").then()
       .contentType(JSON)
       .extract().as(FightImage.class);
@@ -619,7 +622,7 @@ class FightResourceIT {
 
     this.wireMockServer.verify(postRequestedFor(urlEqualTo(NARRATION_API_IMAGE_GEN_URI))
         .withHeader(ACCEPT, containing(APPLICATION_JSON))
-        .withHeader(CONTENT_TYPE, containing(TEXT_PLAIN))
+        .withHeader(CONTENT_TYPE, containing(APPLICATION_JSON))
     );
   }
 
@@ -633,10 +636,12 @@ class FightResourceIT {
         .willReturn(serverError())
     );
 
+    var request = new ImageGenerationRequest(DEFAULT_NARRATION, null, null);
+
     var image = given()
       .accept(JSON)
-      .contentType(TEXT)
-      .body(DEFAULT_NARRATION)
+      .contentType(JSON)
+      .body(request)
       .when().post("/api/fights/narrate/image").then()
       .contentType(JSON)
       .extract().as(FightImage.class);
@@ -649,7 +654,7 @@ class FightResourceIT {
     this.wireMockServer.verify(moreThanOrExactly(3),
       postRequestedFor(urlEqualTo(NARRATION_API_IMAGE_GEN_URI))
         .withHeader(ACCEPT, containing(APPLICATION_JSON))
-        .withHeader(CONTENT_TYPE, containing(TEXT_PLAIN))
+        .withHeader(CONTENT_TYPE, containing(APPLICATION_JSON))
     );
   }
 
@@ -676,11 +681,13 @@ class FightResourceIT {
 					.setParam("http.socket.timeout", delay * 4)
 			);
 
+    var request = new ImageGenerationRequest(DEFAULT_NARRATION, null, null);
+
     var image = given()
 	    .config(config)
       .accept(JSON)
-      .contentType(TEXT)
-      .body(DEFAULT_NARRATION)
+      .contentType(JSON)
+      .body(request)
       .when().post("/api/fights/narrate/image").then()
         .contentType(JSON)
         .extract().as(FightImage.class);
@@ -693,7 +700,7 @@ class FightResourceIT {
     this.wireMockServer.verify(moreThanOrExactly(3),
       postRequestedFor(urlEqualTo(NARRATION_API_IMAGE_GEN_URI))
         .withHeader(ACCEPT, containing(APPLICATION_JSON))
-        .withHeader(CONTENT_TYPE, containing(TEXT_PLAIN))
+        .withHeader(CONTENT_TYPE, containing(APPLICATION_JSON))
     );
   }
 
@@ -1607,6 +1614,7 @@ class FightResourceIT {
     );
 
     var fight = createFightToNarrateHeroWon();
+    var imageRequest = new ImageGenerationRequest(DEFAULT_NARRATION, null, null);
 
     // The circuit breaker requestVolumeThreshold == 8, so we need to make n+1 successful requests for it to clear
     IntStream.rangeClosed(0, 8)
@@ -1626,8 +1634,8 @@ class FightResourceIT {
 
           var image = given()
             .accept(JSON)
-            .contentType(TEXT)
-            .body(DEFAULT_NARRATION)
+            .contentType(JSON)
+            .body(imageRequest)
             .when().post("/api/fights/narrate/image").then()
             .statusCode(OK.getStatusCode())
             .contentType(JSON)
@@ -1650,7 +1658,7 @@ class FightResourceIT {
     this.wireMockServer.verify(9,
 			postRequestedFor(urlEqualTo(NARRATION_API_IMAGE_GEN_URI))
 				.withHeader(ACCEPT, containing(APPLICATION_JSON))
-        .withHeader(CONTENT_TYPE, containing(TEXT_PLAIN))
+        .withHeader(CONTENT_TYPE, containing(APPLICATION_JSON))
 		);
 
 		// Reset all the mocks on the WireMockServer

--- a/rest-fights/src/test/java/io/quarkus/sample/superheroes/fight/rest/FightResourceTests.java
+++ b/rest-fights/src/test/java/io/quarkus/sample/superheroes/fight/rest/FightResourceTests.java
@@ -25,6 +25,7 @@ import io.quarkus.sample.superheroes.fight.FightImage;
 import io.quarkus.sample.superheroes.fight.FightLocation;
 import io.quarkus.sample.superheroes.fight.FightRequest;
 import io.quarkus.sample.superheroes.fight.Fighters;
+import io.quarkus.sample.superheroes.fight.ImageGenerationRequest;
 import io.quarkus.sample.superheroes.fight.client.FightToNarrate;
 import io.quarkus.sample.superheroes.fight.client.FightToNarrate.FightToNarrateLocation;
 import io.quarkus.sample.superheroes.fight.client.Hero;
@@ -187,13 +188,14 @@ public class FightResourceTests {
   @Test
   void shouldGenerateAnImageFromNarration() {
     var image = new FightImage(DEFAULT_IMAGE_URL);
+    var request = new ImageGenerationRequest(DEFAULT_NARRATION, null, null);
 
-    when(this.fightService.generateImageFromNarration(DEFAULT_NARRATION))
+    when(this.fightService.generateImageFromNarration(request))
       .thenReturn(Uni.createFrom().item(image));
 
     var generatedImage = given()
-      .body(DEFAULT_NARRATION)
-      .contentType(TEXT)
+      .body(request)
+      .contentType(JSON)
       .accept(JSON)
       .when().post("/api/fights/narrate/image").then()
         .statusCode(OK.getStatusCode())
@@ -205,14 +207,14 @@ public class FightResourceTests {
       .usingRecursiveAssertion()
       .isEqualTo(image);
 
-    verify(this.fightService).generateImageFromNarration(DEFAULT_NARRATION);
+    verify(this.fightService).generateImageFromNarration(request);
     verifyNoMoreInteractions(this.fightService);
   }
 
   @Test
   void shouldNotGetGeneratedImageForNarrationBecauseInvalidNarration() {
     given()
-      .contentType(TEXT)
+      .contentType(JSON)
       .accept(JSON)
       .when().post("/api/fights/narrate/image").then()
       .statusCode(BAD_REQUEST.getStatusCode());

--- a/rest-fights/src/test/java/io/quarkus/sample/superheroes/fight/service/FightServiceConsumerContractTests.java
+++ b/rest-fights/src/test/java/io/quarkus/sample/superheroes/fight/service/FightServiceConsumerContractTests.java
@@ -27,6 +27,8 @@ import io.quarkus.test.junit.mockito.InjectSpy;
 import io.quarkus.sample.superheroes.fight.Fight;
 import io.quarkus.sample.superheroes.fight.FightImage;
 import io.quarkus.sample.superheroes.fight.Fighters;
+import io.quarkus.sample.superheroes.fight.ImageGenerationRequest;
+import io.quarkus.sample.superheroes.fight.client.NarrationImageGenerationRequest;
 import io.quarkus.sample.superheroes.fight.client.Hero;
 import io.quarkus.sample.superheroes.fight.client.HeroClient;
 import io.quarkus.sample.superheroes.fight.client.LocationClient;
@@ -265,15 +267,22 @@ public class FightServiceConsumerContractTests extends FightServiceTestsBase {
         .stringType("imageUrl", DEFAULT_NARRATION_IMAGE_URL)
     ).build();
 
+    var requestBody = newJsonBody(body ->
+      body
+        .stringType("narration", DEFAULT_NARRATION)
+        .stringType("winnerPictureUrl", DEFAULT_HERO_PICTURE)
+        .stringType("loserPictureUrl", DEFAULT_VILLAIN_PICTURE)
+    ).build();
+
     return builder
       .uponReceiving("A request to generate an image from a narration")
         .path(NARRATION_IMAGE_GEN_URI)
         .method(HttpMethod.POST)
         .headers(
           HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON,
-          HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN
+          HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON
         )
-        .body(PactDslRootValue.stringMatcher("[.\\s\\S]+", DEFAULT_NARRATION))
+        .body(requestBody)
       .willRespondWith()
         .headers(Map.of(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON))
         .status(Status.OK.getStatusCode())
@@ -528,7 +537,9 @@ public class FightServiceConsumerContractTests extends FightServiceTestsBase {
   void generateImageFromNarrationSuccess() {
     PanacheMock.mock(Fight.class);
 
-    var fightImage = this.fightService.generateImageFromNarration(DEFAULT_NARRATION)
+    var request = new ImageGenerationRequest(DEFAULT_NARRATION, DEFAULT_HERO_PICTURE, DEFAULT_VILLAIN_PICTURE);
+
+    var fightImage = this.fightService.generateImageFromNarration(request)
       .subscribe().withSubscriber(UniAssertSubscriber.create())
       .assertSubscribed()
       .awaitItem(Duration.ofSeconds(5))
@@ -539,8 +550,8 @@ public class FightServiceConsumerContractTests extends FightServiceTestsBase {
       .usingRecursiveAssertion()
       .isEqualTo(new FightImage(DEFAULT_NARRATION_IMAGE_URL));
 
-    verify(this.narrationClient).generateImageFromNarration(DEFAULT_NARRATION);
-    verify(this.fightService, never()).fallbackGenerateImageFromNarration(DEFAULT_NARRATION);
+    verify(this.narrationClient).generateImageFromNarration(any(NarrationImageGenerationRequest.class));
+    verify(this.fightService, never()).fallbackGenerateImageFromNarration(request);
     verifyNoInteractions(this.heroClient, this.villainClient, this.locationClient);
 		PanacheMock.verifyNoInteractions(Fight.class);
   }

--- a/rest-fights/src/test/java/io/quarkus/sample/superheroes/fight/service/FightServiceTests.java
+++ b/rest-fights/src/test/java/io/quarkus/sample/superheroes/fight/service/FightServiceTests.java
@@ -30,6 +30,8 @@ import io.quarkus.sample.superheroes.fight.Fight;
 import io.quarkus.sample.superheroes.fight.FightImage;
 import io.quarkus.sample.superheroes.fight.FightRequest;
 import io.quarkus.sample.superheroes.fight.Fighters;
+import io.quarkus.sample.superheroes.fight.ImageGenerationRequest;
+import io.quarkus.sample.superheroes.fight.client.NarrationImageGenerationRequest;
 import io.quarkus.sample.superheroes.fight.ShorterTimeoutsProfile;
 import io.quarkus.sample.superheroes.fight.client.FightToNarrate;
 import io.quarkus.sample.superheroes.fight.client.Hero;
@@ -538,14 +540,15 @@ class FightServiceTests extends FightServiceTestsBase {
   @Test
   void generateFightImageFromNarrationTimesOut() {
     var timeout = Duration.ofSeconds(ShorterTimeoutsProfile.NARRATION_OVERRIDDEN_TIMEOUT + 1);
+    var request = new ImageGenerationRequest(DEFAULT_NARRATION, null, null);
 
-    when(this.narrationClient.generateImageFromNarration(DEFAULT_NARRATION))
+    when(this.narrationClient.generateImageFromNarration(any(NarrationImageGenerationRequest.class)))
       .thenReturn(
         Uni.createFrom().item(IMAGE)
           .onItem().delayIt().by(timeout)
       );
 
-    var image = this.fightService.generateImageFromNarration(DEFAULT_NARRATION)
+    var image = this.fightService.generateImageFromNarration(request)
 			.subscribe().withSubscriber(UniAssertSubscriber.create())
 			.assertSubscribed()
 			.awaitItem(timeout.multipliedBy(4))
@@ -556,17 +559,19 @@ class FightServiceTests extends FightServiceTestsBase {
       .usingRecursiveAssertion()
       .isEqualTo(getFallbackImage());
 
-    verify(this.fightService).generateImageFromNarration(DEFAULT_NARRATION);
-    verify(this.fightService).fallbackGenerateImageFromNarration(DEFAULT_NARRATION);
+    verify(this.fightService).generateImageFromNarration(request);
+    verify(this.fightService).fallbackGenerateImageFromNarration(request);
   }
 
   @Test
   void generateFightFromNarrationError() {
+    var request = new ImageGenerationRequest(DEFAULT_NARRATION, null, null);
+
     doThrow(new RuntimeException())
       .when(this.narrationClient)
-      .generateImageFromNarration(DEFAULT_NARRATION);
+      .generateImageFromNarration(any(NarrationImageGenerationRequest.class));
 
-    var image = this.fightService.generateImageFromNarration(DEFAULT_NARRATION)
+    var image = this.fightService.generateImageFromNarration(request)
 			.subscribe().withSubscriber(UniAssertSubscriber.create())
 			.assertSubscribed()
 			.awaitItem(Duration.ofSeconds(ShorterTimeoutsProfile.NARRATION_OVERRIDDEN_TIMEOUT + 1).multipliedBy(4))
@@ -577,8 +582,8 @@ class FightServiceTests extends FightServiceTestsBase {
       .usingRecursiveAssertion()
       .isEqualTo(getFallbackImage());
 
-    verify(this.fightService).generateImageFromNarration(DEFAULT_NARRATION);
-    verify(this.fightService).fallbackGenerateImageFromNarration(DEFAULT_NARRATION);
+    verify(this.fightService).generateImageFromNarration(request);
+    verify(this.fightService).fallbackGenerateImageFromNarration(request);
   }
 
   @Test

--- a/rest-fights/src/test/resources/pacts/ui-super-heroes-rest-fights.json
+++ b/rest-fights/src/test/resources/pacts/ui-super-heroes-rest-fights.json
@@ -784,9 +784,12 @@
       "pending": false,
       "request": {
         "body": {
-          "content": "This is a default narration - NOT a fallback!\n\nHigh above a bustling city, a symbol of hope and justice soared through the sky, while chaos reigned below, with malevolent laughter echoing through the streets.\nWith unwavering determination, the figure swiftly descended, effortlessly evading explosive attacks, closing the gap, and delivering a decisive blow that silenced the wicked laughter.\n\nIn the end, the battle concluded with a clear victory for the forces of good, as their commitment to peace triumphed over the chaos and villainy that had threatened the city.\nThe people knew that their protector had once again ensured their safety.\n",
-          "contentType": "text/plain",
-          "contentTypeHint": "DEFAULT",
+          "content": {
+            "narration": "This is a default narration - NOT a fallback!\n\nHigh above a bustling city, a symbol of hope and justice soared through the sky, while chaos reigned below, with malevolent laughter echoing through the streets.\nWith unwavering determination, the figure swiftly descended, effortlessly evading explosive attacks, closing the gap, and delivering a decisive blow that silenced the wicked laughter.\n\nIn the end, the battle concluded with a clear victory for the forces of good, as their commitment to peace triumphed over the chaos and villainy that had threatened the city.\nThe people knew that their protector had once again ensured their safety.\n",
+            "winnerPictureUrl": "super_baguette.png",
+            "loserPictureUrl": "super_chocolatine.png"
+          },
+          "contentType": "application/json",
           "encoded": false
         },
         "headers": {
@@ -794,17 +797,32 @@
             "application/json"
           ],
           "Content-Type": [
-            "text/plain"
+            "application/json"
           ]
         },
         "matchingRules": {
           "body": {
-            "$": {
+            "$.narration": {
               "combine": "AND",
               "matchers": [
                 {
-                  "match": "regex",
-                  "regex": "[.\\s\\S]+"
+                  "match": "type"
+                }
+              ]
+            },
+            "$.winnerPictureUrl": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.loserPictureUrl": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
                 }
               ]
             }

--- a/rest-narration/openapi-schema.yml
+++ b/rest-narration/openapi-schema.yml
@@ -79,20 +79,16 @@ paths:
       summary: Generate an image from a narration
       requestBody:
         content:
-          text/plain:
+          application/json:
             schema:
-              pattern: \S
-              type: string
+              $ref: '#/components/schemas/ImageGenerationRequest'
             examples:
-              narration:
-                value: |-
-                  In the dark, shadowy alleys of Gotham City, a fierce battle unfolded between two formidable opponents. The towering, imposing figure known as Chewbacca faced off against the agile and mysterious Wanderer. The air crackled with tension as the two clashed, their powers contrasting starkly against each other.
-
-                  Chewbacca's sheer strength and ferocity were unmatched as he unleashed a flurry of powerful blows, his massive frame dominating the scene. In contrast, Wanderer's quick reflexes and cunning tactics kept him in the fight, dodging and weaving with grace and precision. The clash of styles made for a mesmerizing spectacle as the combatants danced around each other.
-
-                  Despite Wanderer's best efforts, it was clear that Chewbacca's overwhelming power was too much to handle. With a mighty roar, Chewbacca delivered a final, decisive blow that sent Wanderer crashing to the ground. The hero stood victorious, his victory a testament to his incredible strength and unwavering determination.
-
-                  As the dust settled and the citizens of Gotham City breathed a collective sigh of relief, Chewbacca stood tall, a beacon of hope in a city plagued by darkness. The defeated Wanderer, though vanquished, would always be remembered for his valiant effort in the face of insurmountable odds. And so, the tale of their epic clash would be etched into the annals of superhero lore, a testament to the eternal struggle between good and evil.
+              request:
+                value:
+                  narration: In the dark, shadowy alleys of Gotham City, a fierce battle
+                    unfolded between two formidable opponents.
+                  winnerPictureUrl: https://raw.githubusercontent.com/quarkusio/quarkus-super-heroes/characterdata/images/chewbacca--684239239428094811.jpg
+                  loserPictureUrl: https://raw.githubusercontent.com/quarkusio/quarkus-super-heroes/characterdata/images/wanderer-300775911119209178.jpg
         required: true
       responses:
         "200":
@@ -106,7 +102,7 @@ paths:
                   value:
                     imageUrl: https://oaidalleapiprodscus.blob.core.windows.net/private/org-GdpIlMzhC20CU6Tcnu4Qe6B4/user-ljypWMQk95mvH7oFhiClsWLf/img-2YLTLfddXEma581WvHxlOeM3.png?st=2024-03-08T17%3A24%3A42Z&se=2024-03-08T19%3A24%3A42Z&sp=r&sv=2021-08-06&sr=b&rscd=inline&rsct=image/png&skoid=6aaadede-4fb3-4698-a8f6-684d7786b067&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2024-03-08T18%3A14%3A53Z&ske=2024-03-09T18%3A14%3A53Z&sks=b&skv=2021-08-06&sig=Lq0orGMjEy4JOv/xF6guJqx8c4Q7bRrKeAUNAyW2pbw%3D
         "400":
-          description: Invalid (or missing) narration
+          description: Invalid (or missing) request
 components:
   schemas:
     Fight:
@@ -138,6 +134,19 @@ components:
       type: object
       properties:
         imageUrl:
+          type: string
+    ImageGenerationRequest:
+      description: Request for image generation from a narration
+      required:
+      - narration
+      type: object
+      properties:
+        narration:
+          pattern: \S
+          type: string
+        winnerPictureUrl:
+          type: string
+        loserPictureUrl:
           type: string
     FightLocation:
       description: Location of a fight

--- a/rest-narration/src/main/java/io/quarkus/sample/superheroes/narration/ImageGenerationRequest.java
+++ b/rest-narration/src/main/java/io/quarkus/sample/superheroes/narration/ImageGenerationRequest.java
@@ -1,0 +1,9 @@
+package io.quarkus.sample.superheroes.narration;
+
+import jakarta.validation.constraints.NotBlank;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+@Schema(description = "Request for image generation from a narration")
+public record ImageGenerationRequest(@NotBlank String narration, String winnerPictureUrl, String loserPictureUrl) {
+}

--- a/rest-narration/src/main/java/io/quarkus/sample/superheroes/narration/rest/Examples.java
+++ b/rest-narration/src/main/java/io/quarkus/sample/superheroes/narration/rest/Examples.java
@@ -38,4 +38,12 @@ final class Examples {
        "imageUrl": "https://oaidalleapiprodscus.blob.core.windows.net/private/org-GdpIlMzhC20CU6Tcnu4Qe6B4/user-ljypWMQk95mvH7oFhiClsWLf/img-2YLTLfddXEma581WvHxlOeM3.png?st=2024-03-08T17%3A24%3A42Z&se=2024-03-08T19%3A24%3A42Z&sp=r&sv=2021-08-06&sr=b&rscd=inline&rsct=image/png&skoid=6aaadede-4fb3-4698-a8f6-684d7786b067&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2024-03-08T18%3A14%3A53Z&ske=2024-03-09T18%3A14%3A53Z&sks=b&skv=2021-08-06&sig=Lq0orGMjEy4JOv/xF6guJqx8c4Q7bRrKeAUNAyW2pbw%3D"
      }
      """;
+
+  static final String EXAMPLE_IMAGE_GENERATION_REQUEST = """
+     {
+       "narration": "In the dark, shadowy alleys of Gotham City, a fierce battle unfolded between two formidable opponents.",
+       "winnerPictureUrl": "https://raw.githubusercontent.com/quarkusio/quarkus-super-heroes/characterdata/images/chewbacca--684239239428094811.jpg",
+       "loserPictureUrl": "https://raw.githubusercontent.com/quarkusio/quarkus-super-heroes/characterdata/images/wanderer-300775911119209178.jpg"
+     }
+     """;
 }

--- a/rest-narration/src/main/java/io/quarkus/sample/superheroes/narration/rest/NarrationResource.java
+++ b/rest-narration/src/main/java/io/quarkus/sample/superheroes/narration/rest/NarrationResource.java
@@ -1,6 +1,6 @@
 package io.quarkus.sample.superheroes.narration.rest;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
@@ -21,6 +21,7 @@ import io.quarkus.logging.Log;
 
 import io.quarkus.sample.superheroes.narration.Fight;
 import io.quarkus.sample.superheroes.narration.FightImage;
+import io.quarkus.sample.superheroes.narration.ImageGenerationRequest;
 import io.quarkus.sample.superheroes.narration.service.ImageGenerationService;
 import io.quarkus.sample.superheroes.narration.service.NarrationService;
 
@@ -75,7 +76,7 @@ public class NarrationResource {
   @POST
   @Path("/image")
   @Produces(MediaType.APPLICATION_JSON)
-  @Consumes(MediaType.TEXT_PLAIN)
+  @Consumes(MediaType.APPLICATION_JSON)
   @Operation(summary = "Generate an image from a narration")
   @APIResponse(
     responseCode = "200",
@@ -87,21 +88,21 @@ public class NarrationResource {
   )
   @APIResponse(
     responseCode = "400",
-    description = "Invalid (or missing) narration"
+    description = "Invalid (or missing) request"
   )
   public FightImage generateImageFromNarration(
     @RequestBody(
-      name = "narration",
+      name = "request",
       required = true,
       content = @Content(
-        schema = @Schema(implementation = String.class),
-        examples = @ExampleObject(name = "narration", value = Examples.EXAMPLE_NARRATION)
+        schema = @Schema(implementation = ImageGenerationRequest.class),
+        examples = @ExampleObject(name = "request", value = Examples.EXAMPLE_IMAGE_GENERATION_REQUEST)
       )
     )
-    @NotBlank String narration) {
+    @NotNull @Valid ImageGenerationRequest request) {
 
-    var image = this.imageGenerationService.generateImageForNarration(narration);
-    Log.debugf("Image (%s) generated from narration: %s", image, narration);
+    var image = this.imageGenerationService.generateImageForNarration(request);
+    Log.debugf("Image (%s) generated from request: %s", image, request);
 
     return image;
   }

--- a/rest-narration/src/main/java/io/quarkus/sample/superheroes/narration/service/ImageGenerationService.java
+++ b/rest-narration/src/main/java/io/quarkus/sample/superheroes/narration/service/ImageGenerationService.java
@@ -8,6 +8,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import io.quarkus.logging.Log;
 
 import io.quarkus.sample.superheroes.narration.FightImage;
+import io.quarkus.sample.superheroes.narration.ImageGenerationRequest;
 
 import dev.langchain4j.data.image.Image;
 import dev.langchain4j.service.SystemMessage;
@@ -28,9 +29,20 @@ public interface ImageGenerationService {
   Image generateImage(String narration);
 
   @WithSpan("ImageGenerationService.generateImageForNarration")
-  default FightImage generateImageForNarration(@SpanAttribute("arg.narration") String narration) {
-    Log.debugf("Generating image for narration: %s", narration);
-    var image = generateImage(narration);
+  default FightImage generateImageForNarration(@SpanAttribute("arg.request") ImageGenerationRequest request) {
+    Log.debugf("Generating image for request: %s", request);
+
+    var promptBuilder = new StringBuilder(request.narration());
+
+    if (request.winnerPictureUrl() != null && !request.winnerPictureUrl().isBlank()) {
+      promptBuilder.append("\n\nThe winner's appearance can be referenced from: ").append(request.winnerPictureUrl());
+    }
+
+    if (request.loserPictureUrl() != null && !request.loserPictureUrl().isBlank()) {
+      promptBuilder.append("\nThe loser's appearance can be referenced from: ").append(request.loserPictureUrl());
+    }
+
+    var image = generateImage(promptBuilder.toString());
     var imageUrl = Optional.ofNullable(image.url())
       .map(URI::toString)
       .orElseGet(() -> "data:%s;base64,%s".formatted(Optional.ofNullable(image.mimeType()).orElse("image/png"), image.base64Data()));

--- a/rest-narration/src/test/java/io/quarkus/sample/superheroes/narration/rest/NarrationResourceIT.java
+++ b/rest-narration/src/test/java/io/quarkus/sample/superheroes/narration/rest/NarrationResourceIT.java
@@ -23,6 +23,7 @@ import io.quarkus.test.junit.TestProfile;
 import io.quarkus.sample.superheroes.narration.Fight;
 import io.quarkus.sample.superheroes.narration.Fight.FightLocation;
 import io.quarkus.sample.superheroes.narration.FightImage;
+import io.quarkus.sample.superheroes.narration.ImageGenerationRequest;
 import io.quarkus.sample.superheroes.narration.rest.NarrationResourceIT.WiremockOpenAITestProfile;
 import io.quarkus.sample.superheroes.narration.service.ImageGenerationService;
 import io.quarkus.sample.superheroes.narration.service.NarrationService;
@@ -147,9 +148,11 @@ class NarrationResourceIT {
 
   @Test
   void shouldGenerateAnImageFromNarration() {
+    var request = new ImageGenerationRequest(EXPECTED_NARRATION, null, null);
+
     var generatedImage = given()
-      .body(EXPECTED_NARRATION)
-      .contentType(TEXT)
+      .body(request)
+      .contentType(JSON)
       .accept(JSON)
       .when().post("/api/narration/image").then()
         .statusCode(OK.getStatusCode())
@@ -213,7 +216,7 @@ class NarrationResourceIT {
   @Test
   void invalidNarrationToFetchImage() {
     given()
-      .contentType(TEXT)
+      .contentType(JSON)
       .accept(JSON)
       .when()
       .post("/api/narration/image").then()

--- a/rest-narration/src/test/java/io/quarkus/sample/superheroes/narration/rest/NarrationResourceTest.java
+++ b/rest-narration/src/test/java/io/quarkus/sample/superheroes/narration/rest/NarrationResourceTest.java
@@ -18,6 +18,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.sample.superheroes.narration.Fight;
 import io.quarkus.sample.superheroes.narration.Fight.FightLocation;
 import io.quarkus.sample.superheroes.narration.FightImage;
+import io.quarkus.sample.superheroes.narration.ImageGenerationRequest;
 import io.quarkus.sample.superheroes.narration.service.ImageGenerationService;
 import io.quarkus.sample.superheroes.narration.service.NarrationService;
 
@@ -105,14 +106,15 @@ class NarrationResourceTest {
 
   @Test
   void shouldGenerateAnImageFromNarration() {
+    var request = new ImageGenerationRequest(NARRATION, "https://winner.png", "https://loser.png");
     var image = new FightImage(DEFAULT_IMAGE_URL);
 
-    when(this.imageGenerationService.generateImageForNarration(NARRATION))
+    when(this.imageGenerationService.generateImageForNarration(request))
       .thenReturn(image);
 
     var generatedImage = given()
-      .body(NARRATION)
-      .contentType(TEXT)
+      .body(request)
+      .contentType(JSON)
       .accept(JSON)
       .when().post("/api/narration/image").then()
         .statusCode(OK.getStatusCode())
@@ -124,7 +126,7 @@ class NarrationResourceTest {
       .usingRecursiveAssertion()
       .isEqualTo(image);
 
-    verify(this.imageGenerationService).generateImageForNarration(NARRATION);
+    verify(this.imageGenerationService).generateImageForNarration(request);
     verifyNoMoreInteractions(this.imageGenerationService);
     verifyNoInteractions(this.narrationService);
   }
@@ -143,7 +145,7 @@ class NarrationResourceTest {
   @Test
   void invalidNarrationToFetchImage() {
     given()
-      .contentType(TEXT)
+      .contentType(JSON)
       .accept(JSON)
       .when().post("/api/narration/image").then()
       .statusCode(BAD_REQUEST.getStatusCode());

--- a/rest-narration/src/test/java/io/quarkus/sample/superheroes/narration/service/ImageGenerationServiceTests.java
+++ b/rest-narration/src/test/java/io/quarkus/sample/superheroes/narration/service/ImageGenerationServiceTests.java
@@ -11,6 +11,7 @@ import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 
 import io.quarkus.sample.superheroes.narration.FightImage;
+import io.quarkus.sample.superheroes.narration.ImageGenerationRequest;
 
 import dev.langchain4j.data.image.Image;
 import dev.langchain4j.model.image.ImageModel;
@@ -38,7 +39,7 @@ class ImageGenerationServiceTests {
     when(this.imageModel.generate(startsWith(PROMPT)))
       .thenReturn(Response.from(image));
 
-    assertThat(this.imageGenerationService.generateImageForNarration(NARRATION))
+    assertThat(this.imageGenerationService.generateImageForNarration(new ImageGenerationRequest(NARRATION, null, null)))
       .isNotNull()
       .extracting(FightImage::imageUrl)
       .isEqualTo("data:image/png;base64,base64Data");

--- a/rest-narration/src/test/resources/pacts/rest-fights-rest-narration.json
+++ b/rest-narration/src/test/resources/pacts/rest-fights-rest-narration.json
@@ -64,9 +64,12 @@
       "pending": false,
       "request": {
         "body": {
-          "content": "This is a default narration - NOT a fallback!\n\nHigh above a bustling city, a symbol of hope and justice soared through the sky, while chaos reigned below, with malevolent laughter echoing through the streets.\nWith unwavering determination, the figure swiftly descended, effortlessly evading explosive attacks, closing the gap, and delivering a decisive blow that silenced the wicked laughter.\n\nIn the end, the battle concluded with a clear victory for the forces of good, as their commitment to peace triumphed over the chaos and villainy that had threatened the city.\nThe people knew that their protector had once again ensured their safety.\n",
-          "contentType": "text/plain",
-          "contentTypeHint": "DEFAULT",
+          "content": {
+            "narration": "This is a default narration - NOT a fallback!\n\nHigh above a bustling city, a symbol of hope and justice soared through the sky, while chaos reigned below, with malevolent laughter echoing through the streets.\nWith unwavering determination, the figure swiftly descended, effortlessly evading explosive attacks, closing the gap, and delivering a decisive blow that silenced the wicked laughter.\n\nIn the end, the battle concluded with a clear victory for the forces of good, as their commitment to peace triumphed over the chaos and villainy that had threatened the city.\nThe people knew that their protector had once again ensured their safety.\n",
+            "winnerPictureUrl": "super_baguette.png",
+            "loserPictureUrl": "super_chocolatine.png"
+          },
+          "contentType": "application/json",
           "encoded": false
         },
         "headers": {
@@ -74,17 +77,32 @@
             "application/json"
           ],
           "Content-Type": [
-            "text/plain"
+            "application/json"
           ]
         },
         "matchingRules": {
           "body": {
-            "$": {
+            "$.narration": {
               "combine": "AND",
               "matchers": [
                 {
-                  "match": "regex",
-                  "regex": "[.\\s\\S]+"
+                  "match": "type"
+                }
+              ]
+            },
+            "$.winnerPictureUrl": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.loserPictureUrl": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
                 }
               ]
             }

--- a/ui-super-heroes/src/main/webui/src/app/fight/Fight.js
+++ b/ui-super-heroes/src/main/webui/src/app/fight/Fight.js
@@ -29,7 +29,7 @@ function Fight({onFight}) {
 
   const createImage = () => {
     trackPromise(
-        generateImage(narration)
+        generateImage(narration, fightResult?.winnerPicture, fightResult?.loserPicture)
             .then(answer => setGeneratedImage(answer))
             .then(answer => flipCard('narration-flip-card'))
     )

--- a/ui-super-heroes/src/main/webui/src/app/fight/Fight.test.js
+++ b/ui-super-heroes/src/main/webui/src/app/fight/Fight.test.js
@@ -193,7 +193,7 @@ describe("the fight visualisation", () => {
       await act(async () => {
         fireEvent.click(screen.getByText(/GENERATE NARRATION IMAGE/i))
       })
-      expect(generateImage).toHaveBeenLastCalledWith(narration)
+      expect(generateImage).toHaveBeenLastCalledWith(narration, fight.winnerPicture, fight.loserPicture)
     })
 
      it("triggers the onFight callback", async () => {

--- a/ui-super-heroes/src/main/webui/src/app/shared/api/fight-service.js
+++ b/ui-super-heroes/src/main/webui/src/app/shared/api/fight-service.js
@@ -127,17 +127,19 @@ export async function narrateFight(body) {
  * Generates an image from a narration
  *
  * @param narration the narration
+ * @param winnerPictureUrl the winner's picture URL
+ * @param loserPictureUrl the loser's picture URL
  */
-export async function generateImage(narration) {
+export async function generateImage(narration, winnerPictureUrl, loserPictureUrl) {
 
   if (narration === null || narration === undefined) {
     throw new Error('Required parameter narration was null or undefined when calling generateImage.')
   }
 
-  const headers = {...defaultHeaders, 'Accept': 'application/json', 'Content-Type': 'text/plain'}
+  const headers = {...defaultHeaders, 'Accept': 'application/json'}
 
   const response = await axios.post(`${basePath}/api/fights/narrate/image`,
-    narration,
+    { narration, winnerPictureUrl, loserPictureUrl },
     {
       crossDomain: true,
       headers,

--- a/ui-super-heroes/src/main/webui/src/app/shared/api/fight-service.test.js
+++ b/ui-super-heroes/src/main/webui/src/app/shared/api/fight-service.test.js
@@ -233,13 +233,13 @@ describe("the fight service", () => {
     })
 
     it("invokes the remote api", async () => {
-      await generateImage(narrationData)
+      await generateImage(narrationData, "https://winner.png", "https://loser.png")
       expect(axios.post).toHaveBeenCalled()
-      expect(axios.post).toHaveBeenLastCalledWith(expect.anything(), narrationData, expect.anything())
+      expect(axios.post).toHaveBeenLastCalledWith(expect.anything(), { narration: narrationData, winnerPictureUrl: "https://winner.png", loserPictureUrl: "https://loser.png" }, expect.anything())
     })
 
     it("generates an image", async () => {
-      const answer = await generateImage(narrationData)
+      const answer = await generateImage(narrationData, null, null)
       expect(answer).toStrictEqual(narrationImageData)
     })
   })


### PR DESCRIPTION
## Summary

- Change the image generation API from plain text narration to a JSON `ImageGenerationRequest` containing the narration plus winner/loser picture URLs
- The image generation prompt now includes these URLs so the model has visual reference for the fighters' appearances
- Remove the `imageNarration` field from `FightImage` and the "Generated Image Caption" display from the UI
- In rest-fights, decouple API-facing `ImageGenerationRequest` from the downstream `NarrationImageGenerationRequest` client DTO via a MapStruct mapper, following existing patterns (`FightMapper`, `LocationMapper`)

## Test plan

- [ ] `./mvnw clean verify -DskipITs -pl rest-narration` passes
- [ ] `./mvnw clean verify -DskipITs -pl rest-fights` passes
- [ ] `./mvnw clean verify -DskipITs -pl ui-super-heroes` passes
- [ ] Run in dev mode and verify image generation works with fighter picture URLs included in the prompt
- [ ] Verify the "Generated Image Caption" is no longer displayed in the UI