### PR TITLE
Update broken documentation URLs in READMEs and docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Quarkus Superheroes Sample
 
-> **Full documentation: [https://quarkus-super-heroes.quarkus.io](https://quarkus-super-heroes.quarkus.io)**
+> **Full documentation: [https://quarkus.io/quarkus-super-heroes](https://quarkus.io/quarkus-super-heroes)**
 
 ## Introduction
 
@@ -29,7 +29,7 @@ The main UI allows you to pick one random Hero and Villain by clicking on _New F
 
 ## Running Locally
 
-See the [Running Locally](https://quarkus-super-heroes.quarkus.io/running-locally) guide for Docker Compose instructions, or run any individual service in dev mode:
+See the [Running Locally](https://quarkus.io/quarkus-super-heroes/running-locally) guide for Docker Compose instructions, or run any individual service in dev mode:
 
 ```bash
 cd rest-heroes && ./mvnw quarkus:dev
@@ -37,8 +37,8 @@ cd rest-heroes && ./mvnw quarkus:dev
 
 ## Deploying to Kubernetes
 
-See the [Deploying to Kubernetes](https://quarkus-super-heroes.quarkus.io/deploying) guide for full instructions on deploying to OpenShift, Minikube, Kubernetes, and Knative using pre-built images, Helm charts, or Quarkus Kubernetes Extensions.
+See the [Deploying to Kubernetes](https://quarkus.io/quarkus-super-heroes/deploying) guide for full instructions on deploying to OpenShift, Minikube, Kubernetes, and Knative using pre-built images, Helm charts, or Quarkus Kubernetes Extensions.
 
 ## CI/CD Automation
 
-See the [CI/CD Automation](https://quarkus-super-heroes.quarkus.io/automation) guide for details on the GitHub Action workflows and application resource generation.
+See the [CI/CD Automation](https://quarkus.io/quarkus-super-heroes/automation) guide for details on the GitHub Action workflows and application resource generation.

--- a/docs/src/main/resources/content/rest-narration.md
+++ b/docs/src/main/resources/content/rest-narration.md
@@ -9,7 +9,7 @@ content-toc: true
 
 This is the Narration REST API microservice. It is a blocking HTTP microservice using the [Quarkus LangChain4J extension](https://docs.quarkiverse.io/quarkus-langchain4j/dev/index.html) to integrate with an AI service to generate text narrating a given fight.
 
-The Narration microservice needs to access an AI service to generate the text narrating the fight. The codebase uses [OpenAI](https://openai.com/) via the [`quarkus-langchain4j-openai` extension](https://docs.quarkiverse.io/quarkus-langchain4j/dev/openai.html).
+The Narration microservice needs to access an AI service to generate the text narrating the fight. The codebase uses [OpenAI](https://openai.com/) via the [`quarkus-langchain4j-openai` extension](https://docs.quarkiverse.io/quarkus-langchain4j/dev/openai-chat-model.html).
 
 Additionally, the service can generate images and image captions from a narration using [DALL-E](https://openai.com/research/dall-e).
 
@@ -51,7 +51,7 @@ From the `quarkus-super-heroes/rest-narration` directory, simply run `./mvnw qua
 
 ## Integration with OpenAI Providers
 
-The application uses [OpenAI](https://openai.com/) via the [`quarkus-langchain4j-openai` extension](https://docs.quarkiverse.io/quarkus-langchain4j/dev/openai.html). This integration requires creating resources on OpenAI in order to work properly.
+The application uses [OpenAI](https://openai.com/) via the [`quarkus-langchain4j-openai` extension](https://docs.quarkiverse.io/quarkus-langchain4j/dev/openai-chat-model.html). This integration requires creating resources on OpenAI in order to work properly.
 
 **CAUTION:** Using OpenAI may not be a free resource for you, so please understand this! Unless configured otherwise, this application does **NOT** communicate with any external service. Instead, by default, it just returns a default narration.
 

--- a/event-statistics/README.md
+++ b/event-statistics/README.md
@@ -1,6 +1,6 @@
 # Superheroes Event Statistics Microservice
 
-> **Full documentation: [https://quarkus-super-heroes.quarkus.io/event-statistics](https://quarkus-super-heroes.quarkus.io/event-statistics)**
+> **Full documentation: [https://quarkus.io/quarkus-super-heroes/event-statistics](https://quarkus.io/quarkus-super-heroes/event-statistics)**
 
 ## Introduction
 

--- a/grpc-locations/README.md
+++ b/grpc-locations/README.md
@@ -1,6 +1,6 @@
 # Superheroes Location Microservice
 
-> **Full documentation: [https://quarkus-super-heroes.quarkus.io/grpc-locations](https://quarkus-super-heroes.quarkus.io/grpc-locations)**
+> **Full documentation: [https://quarkus.io/quarkus-super-heroes/grpc-locations](https://quarkus.io/quarkus-super-heroes/grpc-locations)**
 
 ## Introduction
 

--- a/rest-fights/README.md
+++ b/rest-fights/README.md
@@ -1,6 +1,6 @@
 # Superheroes Fight Microservice
 
-> **Full documentation: [https://quarkus-super-heroes.quarkus.io/rest-fights](https://quarkus-super-heroes.quarkus.io/rest-fights)**
+> **Full documentation: [https://quarkus.io/quarkus-super-heroes/rest-fights](https://quarkus.io/quarkus-super-heroes/rest-fights)**
 
 ## Introduction
 

--- a/rest-heroes/README.md
+++ b/rest-heroes/README.md
@@ -1,6 +1,6 @@
 # Superheroes Hero Microservice
 
-> **Full documentation: [https://quarkus-super-heroes.quarkus.io/rest-heroes](https://quarkus-super-heroes.quarkus.io/rest-heroes)**
+> **Full documentation: [https://quarkus.io/quarkus-super-heroes/rest-heroes](https://quarkus.io/quarkus-super-heroes/rest-heroes)**
 
 ## Introduction
 

--- a/rest-narration/README.md
+++ b/rest-narration/README.md
@@ -1,12 +1,12 @@
 # Superheroes Narration Microservice
 
-> **Full documentation: [https://quarkus-super-heroes.quarkus.io/rest-narration](https://quarkus-super-heroes.quarkus.io/rest-narration)**
+> **Full documentation: [https://quarkus.io/quarkus-super-heroes/rest-narration](https://quarkus.io/quarkus-super-heroes/rest-narration)**
 
 ## Introduction
 
 This is the Narration REST API microservice. It is a blocking HTTP microservice using the [Quarkus LangChain4J extension](https://docs.quarkiverse.io/quarkus-langchain4j/dev/index.html) to integrate with an AI service to generate text narrating a given fight.
 
-The Narration microservice needs to access an AI service to generate the text narrating the fight. The codebase uses [OpenAI](https://openai.com/) via the [`quarkus-langchain4j-openai` extension](https://docs.quarkiverse.io/quarkus-langchain4j/dev/openai.html). Additionally, the service can generate images and image captions from a narration using [DALL-E](https://openai.com/research/dall-e).
+The Narration microservice needs to access an AI service to generate the text narrating the fight. The codebase uses [OpenAI](https://openai.com/) via the [`quarkus-langchain4j-openai` extension](https://docs.quarkiverse.io/quarkus-langchain4j/dev/openai-chat-model.html). Additionally, the service can generate images and image captions from a narration using [DALL-E](https://openai.com/research/dall-e).
 
 This service is implemented using [RESTEasy Reactive](https://quarkus.io/guides/resteasy-reactive) with blocking endpoints. It uses a **contract-first** approach: the REST API interface is generated at build time from the OpenAPI specification ([`src/main/resources/openapi/openapi.yml`](src/main/resources/openapi/openapi.yml)) using the [Quarkiverse OpenAPI Generator Server extension](https://docs.quarkiverse.io/quarkus-openapi-generator/dev/server.html).
 

--- a/rest-villains/README.md
+++ b/rest-villains/README.md
@@ -1,6 +1,6 @@
 # Superheroes Villain Microservice
 
-> **Full documentation: [https://quarkus-super-heroes.quarkus.io/rest-villains](https://quarkus-super-heroes.quarkus.io/rest-villains)**
+> **Full documentation: [https://quarkus.io/quarkus-super-heroes/rest-villains](https://quarkus.io/quarkus-super-heroes/rest-villains)**
 
 ## Introduction
 

--- a/ui-super-heroes/README.md
+++ b/ui-super-heroes/README.md
@@ -1,6 +1,6 @@
 # Superheroes Battle UI
 
-> **Full documentation: [https://quarkus-super-heroes.quarkus.io/ui-super-heroes](https://quarkus-super-heroes.quarkus.io/ui-super-heroes)**
+> **Full documentation: [https://quarkus.io/quarkus-super-heroes/ui-super-heroes](https://quarkus.io/quarkus-super-heroes/ui-super-heroes)**
 
 ## Introduction
 


### PR DESCRIPTION
## Summary

- Updates all documentation URLs from the old domain (`quarkus-super-heroes.quarkus.io`) to the new domain (`quarkus.io/quarkus-super-heroes`) across 8 README files (11 occurrences)
- Updates the broken quarkus-langchain4j OpenAI extension link (`openai.html` → `openai-chat-model.html`) in `rest-narration/README.md` and `docs/src/main/resources/content/rest-narration.md`

Closes #2187
Closes #2188

## Test plan

- [x] Verified all 44 unique external URLs across all READMEs return HTTP 200
- [x] Confirmed zero remaining references to old domain: `grep -r "quarkus-super-heroes.quarkus.io" --include="*.md" .`
- [x] Confirmed zero remaining references to old langchain4j URL: `grep -r "quarkus-langchain4j/dev/openai.html" --include="*.md" .`